### PR TITLE
fix: prevent docs-only merge-base failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Fetch base branch for diff
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Pull Request

## Summary
- fetch full history for docs-only detection to avoid merge-base failures

## Issue Linkage
- Fixes #15

## Testing
- `poetry run python3 scripts/dev/validate_local.py --base-ref develop`

## Notes
- Ensures `git diff origin/<base>...HEAD` can compute a merge base in PR runs.
