### PR TITLE
fix: make docs-only detection merge-base independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Fetch base branch for diff
-        if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }} --depth=1
-
       - name: Detect docs-only changes
         id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          files=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
           if [ -z "$files" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
# Pull Request

## Summary
- use GitHub API file list for docs-only detection to avoid merge-base errors

## Issue Linkage
- Fixes #17

## Testing
- `poetry run python3 scripts/dev/validate_local.py --base-ref develop`

## Notes
- Docs-only detection now relies on PR file metadata instead of git diff.
