### PR TITLE
Adopt standards include bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # pymqrest Agent Instructions
 
+#include standards-and-conventions.md
+
 ## User Overrides (Optional)
 
 If `~/AGENTS.md` exists and is readable, load it and apply it as a

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -5,55 +5,10 @@ https://github.com/wphillipmoore/standards-and-conventions
 
 ## Table of Contents
 - [Canonical references](#canonical-references)
-  - [Core references (always required)](#core-references-always-required)
-  - [Repository-type references (required for the declared type)](#repository-type-references-required-for-the-declared-type)
-  - [Additional required references](#additional-required-references)
 - [Project-specific overlay](#project-specific-overlay)
-  - [AI co-authors](#ai-co-authors)
-  - [Repository profile](#repository-profile)
-  - [Local validation](#local-validation)
-  - [Tooling requirement](#tooling-requirement)
 
 ## Canonical references
-
-### Core references (always required)
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/markdown-standards.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/repository-types-and-attributes.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/commit-messages-and-authorship.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/github-issues.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/source-control-guidelines.md
-
-### Repository-type references (required for the declared type)
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/library-branching-and-release.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/library-versioning-scheme.md
-
-### Additional required references
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/environment-and-tooling.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/overview.md
+#include ../standards-and-conventions/docs/standards-and-conventions.md
 
 ## Project-specific overlay
-
-### AI co-authors
-
-- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
-- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
-
-### Repository profile
-
-- repository_type: library
-- versioning_scheme: library
-- branching_model: library-release
-- release_model: artifact-publishing
-- supported_release_lines: current and previous
-
-### Local validation
-
-- `python3 scripts/dev/validate_local.py`
-- Docs-only changes: `python3 scripts/dev/validate_docs.py`
-- Docs-only validation requires `markdownlint` `0.41.0` on the PATH or `npx`
-  to run the pinned version.
-
-### Tooling requirement
-
-- `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`).
+#include repository-standards.md

--- a/repository-standards.md
+++ b/repository-standards.md
@@ -1,0 +1,27 @@
+# pymqrest Repository Standards
+
+## Table of Contents
+- [AI co-authors](#ai-co-authors)
+- [Repository profile](#repository-profile)
+- [Local validation](#local-validation)
+- [Tooling requirement](#tooling-requirement)
+
+## AI co-authors
+- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
+- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
+
+## Repository profile
+- repository_type: library
+- versioning_scheme: library
+- branching_model: library-release
+- release_model: artifact-publishing
+- supported_release_lines: current and previous
+
+## Local validation
+- `python3 scripts/dev/validate_local.py`
+- Docs-only changes: `python3 scripts/dev/validate_docs.py`
+- Docs-only validation requires `markdownlint` `0.41.0` on the PATH or `npx`
+  to run the pinned version.
+
+## Tooling requirement
+- `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`).

--- a/standards-and-conventions.md
+++ b/standards-and-conventions.md
@@ -1,0 +1,7 @@
+# pymqrest Standards Bootstrap
+
+## Table of Contents
+- [Includes](#includes)
+
+## Includes
+#include docs/standards-and-conventions.md


### PR DESCRIPTION
# Pull Request

## Summary
- Adopt include-based standards bootstrap and repository-standards overlay.
- Refresh AGENTS to pull standards via includes.

## Issue Linkage
- Fixes #25

## Testing
- Docs-only: tests skipped.
- `python3 scripts/dev/validate_docs.py` failed: markdownlint version mismatch (expected 0.41.0, found 0.47.0).
- Files changed:
  - AGENTS.md
  - docs/standards-and-conventions.md
  - repository-standards.md
  - standards-and-conventions.md

## Notes
- None.
