### PR TITLE
refactor: simplify define_channel parameters

### DIFF
--- a/docs/mq-rest-wrapper-api-surface.md
+++ b/docs/mq-rest-wrapper-api-surface.md
@@ -134,7 +134,6 @@ Channel definition and deletion commands return `None` on success:
 def define_channel(
     self,
     name: str,
-    channel_type: str,
     request_parameters: RequestParametersType | None = None,
     response_parameters: ResponseParametersType | None = None,
 ) -> None:
@@ -149,6 +148,9 @@ def delete_channel(
 ) -> None:
     ...
 ```
+
+`define_channel` expects `request_parameters` to include `channel_type`; the
+client does not validate required parameters yet.
 
 ## Internal bridge to metadata
 Public methods are thin wrappers over an internal command executor. The

--- a/docs/mq-rest-wrapper-design.md
+++ b/docs/mq-rest-wrapper-design.md
@@ -99,7 +99,6 @@ def define_qlocal(
 
 def define_channel(
     name: str,
-    channel_type: str,
     request_parameters: RequestParametersType | None = None,
     *,
     map_attributes: bool | None = None,
@@ -129,7 +128,7 @@ Conventions:
 - Queue types supported: `QLOCAL`, `QREMOTE`, `QALIAS`, `QMODEL`.
 
 ### Channel methods
-- `define_channel` requires `channel_type`.
+- `define_channel` expects `request_parameters` to include `channel_type`.
 - `display_channel` returns a list; empty list when no objects match.
 - `delete_channel` raises on failure.
 - Channel types supported: `SVRCONN`, `SDR`, `RCVR`, `RQR`, `CLNTCONN`, `CLUSRCVR`, `CLUSSDR`.

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -212,16 +212,14 @@ class MQRESTSession:
     def define_channel(
         self,
         name: str,
-        channel_type: str,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
-        parameters = _merge_parameters(request_parameters, {"channel_type": channel_type})
         self._mqsc_command(
             command="DEFINE",
             mqsc_qualifier="CHANNEL",
             name=name,
-            request_parameters=parameters,
+            request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
 
@@ -477,15 +475,6 @@ def _has_error_codes(completion_code: int | None, reason_code: int | None) -> bo
         (completion_code is not None and completion_code != 0)
         or (reason_code is not None and reason_code != 0)
     )
-
-
-def _merge_parameters(
-    base_parameters: Mapping[str, object] | None,
-    extra_parameters: Mapping[str, object],
-) -> dict[str, object]:
-    merged = dict(base_parameters or {})
-    merged.update(extra_parameters)
-    return merged
 
 
 def _get_command_map() -> Mapping[str, object]:

--- a/tests/pymqrest/test_session.py
+++ b/tests/pymqrest/test_session.py
@@ -304,12 +304,6 @@ def test_resolve_mapping_qualifier_fallbacks() -> None:
     assert session._resolve_mapping_qualifier("BOGUS", "UNKNOWN") == "unknown"
 
 
-def test_merge_parameters_with_base() -> None:
-    merged = session_module._merge_parameters({"base": 1}, {"extra": 2})
-
-    assert merged == {"base": 1, "extra": 2}
-
-
 def test_display_channel_defaults_to_all() -> None:
     response_payload = {
         "commandResponse": [
@@ -341,7 +335,7 @@ def test_define_and_delete_commands_build_payloads() -> None:
 
     session.define_qlocal("TEST.QUEUE")
     session.delete_queue("TEST.QUEUE")
-    session.define_channel("TEST.CHANNEL", channel_type="SVRCONN")
+    session.define_channel("TEST.CHANNEL", request_parameters={"channel_type": "SVRCONN"})
     session.delete_channel("TEST.CHANNEL")
 
     define_queue_request = transport.recorded_requests[0]


### PR DESCRIPTION
## Summary
- Drop explicit channel_type argument from define_channel; rely on request_parameters.
- Update API/design docs and tests to match the streamlined signature.

## Issue Linkage
- Fixes #38

## Testing
- uv run python3 scripts/dev/validate_local.py

## Notes
- None.
