### PR TITLE
feat: expand MQSC command wrappers

### DIFF
--- a/docs/mq-rest-wrapper-api-surface.md
+++ b/docs/mq-rest-wrapper-api-surface.md
@@ -194,6 +194,25 @@ def delete_channel(
 `define_channel` expects `request_parameters` to include `channel_type`; the
 client does not validate required parameters yet.
 
+## MQSC namespace coverage
+`MQRESTSession` now exposes wrappers for every MQSC command listed in
+`docs/mqsc-pcf-command-mapping.md`. Method names follow the pattern
+`<verb>_<qualifier>` with tokens lowercased and spaces converted to underscores.
+
+All generated methods accept:
+- `name: str | None = None`
+- `request_parameters: RequestParametersType | None = None`
+- `response_parameters: ResponseParametersType | None = None`
+
+Return shapes follow these rules:
+- `DISPLAY` commands return a list of objects.
+- `display_qmgr`, `display_qmstatus`, and `display_cmdserv` return a single
+  object or `None`.
+- Non-`DISPLAY` commands return `None`.
+
+Queue/channel convenience methods keep their existing defaults (for example,
+`display_queue` and `display_channel` default `name` to `"*"`).
+
 ## Internal bridge to metadata
 Public methods are thin wrappers over an internal command executor. The
 internal executor accepts MQSC command data and uses collected metadata to

--- a/docs/mq-rest-wrapper-design.md
+++ b/docs/mq-rest-wrapper-design.md
@@ -156,6 +156,18 @@ Conventions:
 - `display_qmstatus` and `display_cmdserv` return a single dict-like object.
 - Missing queue manager returns `None` without raising.
 
+### MQSC namespace coverage
+The session class includes method wrappers for every MQSC command listed in
+`docs/mqsc-pcf-command-mapping.md`. The method naming convention is
+`<verb>_<qualifier>` (lowercase, spaces to underscores). Generated methods
+accept optional `name`, `request_parameters`, and `response_parameters` and
+defer validation to the server.
+
+Return shape rules:
+- `DISPLAY` commands return a list of dict-like objects, except the queue
+  manager helpers that return a single object or `None`.
+- Non-`DISPLAY` commands return `None`.
+
 ## Mapping and typing
 - Attribute mapping pipeline: MQSC -> PCF -> snake_case.
 - Mapping is enabled by default, with opt-out at session init and per-method.

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -313,6 +313,1856 @@ class MQRESTSession:
             response_parameters=response_parameters,
         )
 
+    # BEGIN GENERATED MQSC METHODS
+    def alter_authinfo(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="AUTHINFO",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_buffpool(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="BUFFPOOL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_cfstruct(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="CFSTRUCT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_channel(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="CHANNEL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_comminfo(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="COMMINFO",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_listener(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="LISTENER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_namelist(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="NAMELIST",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_process(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="PROCESS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_psid(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="PSID",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_qmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="QMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_security(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="SECURITY",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_service(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="SERVICE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_smds(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="SMDS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_stgclass(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="STGCLASS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_sub(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="SUB",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_topic(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="TOPIC",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def alter_trace(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier="TRACE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def archive_log(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="ARCHIVE",
+            mqsc_qualifier="LOG",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def backup_cfstruct(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="BACKUP",
+            mqsc_qualifier="CFSTRUCT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def clear_qlocal(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="CLEAR",
+            mqsc_qualifier="QLOCAL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def clear_topicstr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="CLEAR",
+            mqsc_qualifier="TOPICSTR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_authinfo(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="AUTHINFO",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_buffpool(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="BUFFPOOL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_cfstruct(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="CFSTRUCT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_comminfo(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="COMMINFO",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_listener(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="LISTENER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_log(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="LOG",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_maxsmsgs(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="MAXSMSGS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_namelist(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="NAMELIST",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_process(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="PROCESS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_psid(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="PSID",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_service(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="SERVICE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_stgclass(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="STGCLASS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_sub(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="SUB",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def define_topic(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DEFINE",
+            mqsc_qualifier="TOPIC",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_authinfo(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="AUTHINFO",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_authrec(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="AUTHREC",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_buffpool(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="BUFFPOOL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_cfstruct(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="CFSTRUCT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_comminfo(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="COMMINFO",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_listener(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="LISTENER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_namelist(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="NAMELIST",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_policy(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="POLICY",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_process(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="PROCESS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_psid(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="PSID",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_service(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="SERVICE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_stgclass(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="STGCLASS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_sub(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="SUB",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def delete_topic(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="DELETE",
+            mqsc_qualifier="TOPIC",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_apstatus(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="APSTATUS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_archive(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="ARCHIVE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_authinfo(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="AUTHINFO",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_authrec(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="AUTHREC",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_authserv(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="AUTHSERV",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_cfstatus(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="CFSTATUS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_cfstruct(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="CFSTRUCT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_chinit(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="CHINIT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_chlauth(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="CHLAUTH",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_chstatus(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="CHSTATUS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_clusqmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="CLUSQMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_comminfo(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="COMMINFO",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_conn(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="CONN",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_entauth(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="ENTAUTH",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_group(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="GROUP",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_listener(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="LISTENER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_log(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="LOG",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_lsstatus(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="LSSTATUS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_maxsmsgs(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="MAXSMSGS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_namelist(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="NAMELIST",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_policy(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="POLICY",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_process(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="PROCESS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_pubsub(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="PUBSUB",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_qstatus(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="QSTATUS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_sbstatus(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="SBSTATUS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_security(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="SECURITY",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_service(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="SERVICE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_smds(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="SMDS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_smdsconn(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="SMDSCONN",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_stgclass(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="STGCLASS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_sub(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="SUB",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_svstatus(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="SVSTATUS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_system(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="SYSTEM",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_tcluster(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="TCLUSTER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_thread(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="THREAD",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_topic(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="TOPIC",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_tpstatus(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="TPSTATUS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_trace(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="TRACE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def display_usage(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> list[dict[str, object]]:
+        return self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier="USAGE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def move_qlocal(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="MOVE",
+            mqsc_qualifier="QLOCAL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def ping_channel(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="PING",
+            mqsc_qualifier="CHANNEL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def ping_qmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="PING",
+            mqsc_qualifier="QMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def purge_channel(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="PURGE",
+            mqsc_qualifier="CHANNEL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def recover_bsds(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RECOVER",
+            mqsc_qualifier="BSDS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def recover_cfstruct(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RECOVER",
+            mqsc_qualifier="CFSTRUCT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def refresh_cluster(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="REFRESH",
+            mqsc_qualifier="CLUSTER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def refresh_qmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="REFRESH",
+            mqsc_qualifier="QMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def refresh_security(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="REFRESH",
+            mqsc_qualifier="SECURITY",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def reset_cfstruct(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESET",
+            mqsc_qualifier="CFSTRUCT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def reset_channel(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESET",
+            mqsc_qualifier="CHANNEL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def reset_cluster(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESET",
+            mqsc_qualifier="CLUSTER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def reset_qmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESET",
+            mqsc_qualifier="QMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def reset_qstats(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESET",
+            mqsc_qualifier="QSTATS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def reset_smds(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESET",
+            mqsc_qualifier="SMDS",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def reset_tpipe(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESET",
+            mqsc_qualifier="TPIPE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def resolve_channel(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESOLVE",
+            mqsc_qualifier="CHANNEL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def resolve_indoubt(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESOLVE",
+            mqsc_qualifier="INDOUBT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def resume_qmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RESUME",
+            mqsc_qualifier="QMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def rverify_security(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="RVERIFY",
+            mqsc_qualifier="SECURITY",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def set_archive(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="SET",
+            mqsc_qualifier="ARCHIVE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def set_authrec(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="SET",
+            mqsc_qualifier="AUTHREC",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def set_chlauth(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="SET",
+            mqsc_qualifier="CHLAUTH",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def set_log(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="SET",
+            mqsc_qualifier="LOG",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def set_policy(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="SET",
+            mqsc_qualifier="POLICY",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def set_system(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="SET",
+            mqsc_qualifier="SYSTEM",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def start_channel(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier="CHANNEL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def start_chinit(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier="CHINIT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def start_cmdserv(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier="CMDSERV",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def start_listener(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier="LISTENER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def start_qmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier="QMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def start_service(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier="SERVICE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def start_smdsconn(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier="SMDSCONN",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def start_trace(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier="TRACE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_channel(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="CHANNEL",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_chinit(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="CHINIT",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_cmdserv(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="CMDSERV",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_conn(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="CONN",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_listener(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="LISTENER",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_qmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="QMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_service(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="SERVICE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_smdsconn(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="SMDSCONN",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def stop_trace(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier="TRACE",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+
+    def suspend_qmgr(
+        self,
+        name: str | None = None,
+        request_parameters: Mapping[str, object] | None = None,
+        response_parameters: Sequence[str] | None = None,
+    ) -> None:
+        self._mqsc_command(
+            command="SUSPEND",
+            mqsc_qualifier="QMGR",
+            name=name,
+            request_parameters=request_parameters,
+            response_parameters=response_parameters,
+        )
+    # END GENERATED MQSC METHODS
+
     def _mqsc_command(
         self,
         *,


### PR DESCRIPTION
## Summary
- Add wrappers for every MQSC command in docs/mqsc-pcf-command-mapping.md.
- Document generated naming/return conventions for the expanded namespace.
- Add a mapping-driven test that exercises each generated method.

## Issue Linkage
- Fixes #40

## Testing
- uv run python3 scripts/dev/validate_local.py

## Notes
- Includes z/OS-only commands for parity with the full MQSC namespace.
