### PR TITLE
refactor: move mq rest exceptions to module

### DIFF
--- a/src/pymqrest/__init__.py
+++ b/src/pymqrest/__init__.py
@@ -1,5 +1,11 @@
 """pymqrest runtime package."""
 
+from .exceptions import (
+    MQRESTCommandError,
+    MQRESTError,
+    MQRESTResponseError,
+    MQRESTTransportError,
+)
 from .mapping import (
     MappingError,
     MappingIssue,
@@ -7,13 +13,7 @@ from .mapping import (
     map_response_attributes,
     map_response_list,
 )
-from .session import (
-    MQRESTCommandError,
-    MQRESTError,
-    MQRESTResponseError,
-    MQRESTSession,
-    MQRESTTransportError,
-)
+from .session import MQRESTSession
 
 __all__ = [
     "MQRESTCommandError",

--- a/src/pymqrest/exceptions.py
+++ b/src/pymqrest/exceptions.py
@@ -1,0 +1,43 @@
+"""MQ REST exception definitions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class MQRESTError(Exception):
+    """Base error for MQ REST session failures."""
+
+
+class MQRESTTransportError(MQRESTError):
+    """Raised when the transport fails to reach the MQ REST endpoint."""
+
+    def __init__(self, message: str, *, url: str) -> None:
+        super().__init__(message)
+        self.url = url
+
+
+class MQRESTResponseError(MQRESTError):
+    """Raised when the MQ REST response is malformed or unexpected."""
+
+    def __init__(self, message: str, *, response_text: str | None = None) -> None:
+        super().__init__(message)
+        self.response_text = response_text
+
+
+class MQRESTCommandError(MQRESTError):
+    """Raised when the MQ REST response indicates command failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        payload: Mapping[str, object],
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.payload = dict(payload)
+        self.status_code = status_code

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -11,45 +11,15 @@ from typing import Protocol, cast
 import requests
 from requests import RequestException
 
+from .exceptions import (
+    MQRESTCommandError,
+    MQRESTResponseError,
+    MQRESTTransportError,
+)
 from .mapping import map_request_attributes, map_response_list
 from .mapping_data import MAPPING_DATA
 
 DEFAULT_RESPONSE_PARAMETERS: list[str] = ["all"]
-
-
-class MQRESTError(Exception):
-    """Base error for MQ REST session failures."""
-
-
-class MQRESTTransportError(MQRESTError):
-    """Raised when the transport fails to reach the MQ REST endpoint."""
-
-    def __init__(self, message: str, *, url: str) -> None:
-        super().__init__(message)
-        self.url = url
-
-
-class MQRESTResponseError(MQRESTError):
-    """Raised when the MQ REST response is malformed or unexpected."""
-
-    def __init__(self, message: str, *, response_text: str | None = None) -> None:
-        super().__init__(message)
-        self.response_text = response_text
-
-
-class MQRESTCommandError(MQRESTError):
-    """Raised when the MQ REST response indicates command failure."""
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        payload: Mapping[str, object],
-        status_code: int | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.payload = dict(payload)
-        self.status_code = status_code
 
 
 @dataclass(frozen=True)

--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 import pytest
 
-from pymqrest.session import MQRESTError, MQRESTSession
+from pymqrest.exceptions import MQRESTError
+from pymqrest.session import MQRESTSession
 
 INTEGRATION_ENV_FLAG = "PYMQREST_RUN_INTEGRATION"
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/pymqrest/test_session.py
+++ b/tests/pymqrest/test_session.py
@@ -12,14 +12,12 @@ import pytest
 from requests import RequestException
 
 from pymqrest import session as session_module
-from pymqrest.session import (
+from pymqrest.exceptions import (
     MQRESTCommandError,
     MQRESTResponseError,
-    MQRESTSession,
     MQRESTTransportError,
-    RequestsTransport,
-    TransportResponse,
 )
+from pymqrest.session import MQRESTSession, RequestsTransport, TransportResponse
 
 if TYPE_CHECKING:
     from collections.abc import Mapping


### PR DESCRIPTION
## Summary
- move MQ REST exception classes into `exceptions.py`
- update imports to use the new module

## Testing
- uv run python3 scripts/dev/validate_local.py

Fixes #54
