### PR TITLE
chore: unpin markdownlint requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           node-version: "20"
 
       - name: Install markdownlint
-        run: npm install --global markdownlint-cli@0.41.0
+        run: npm install --global markdownlint-cli
 
       - name: Fetch base branch for commit linting
         if: github.event_name == 'pull_request'

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -33,8 +33,7 @@
 
 - `uv run python3 scripts/dev/validate_local.py`
 - Docs-only changes: `uv run python3 scripts/dev/validate_docs.py`
-- Docs-only validation requires `markdownlint` `0.41.0` on the PATH or `npx`
-  to run the pinned version.
+- Docs-only validation requires `markdownlint` on the PATH.
 
 ## Python invocation
 


### PR DESCRIPTION
## Summary
- remove fixed markdownlint version checks in docs validation
- update standards to require markdownlint on PATH without pinning
- install markdownlint-cli in CI without version pin

## Issue Linkage
- Ref #59

## Testing
- uv run python3 scripts/dev/validate_local.py

## Notes
- npx is not used for markdownlint execution
