### PR TITLE
feat: enable strict attribute mapping by default

### DIFF
--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -100,7 +100,7 @@ class MQRESTSession(MQRESTCommandMixin):
         verify_tls: bool = True,
         timeout_seconds: float | None = 30.0,
         map_attributes: bool = True,
-        mapping_strict: bool = False,
+        mapping_strict: bool = True,
         csrf_token: str | None = DEFAULT_CSRF_TOKEN,
         transport: MQRESTTransport | None = None,
     ) -> None:


### PR DESCRIPTION
## Summary
Fixes #62

- Changes `MQRESTSession` default from `mapping_strict=False` to `mapping_strict=True` so unknown attributes raise `MappingError` instead of silently passing through
- Updates 5 unit tests that intentionally exercise lenient behavior to explicitly pass `mapping_strict=False`
- No integration test changes needed (already used `mapping_strict=True`)

## Test plan
- [x] All 71 unit tests pass with 100% branch coverage
- [x] Ruff check and format clean
- [x] mypy passes
- [ ] Integration tests with strict mapping (requires MQ container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)