### PR TITLE
fix: remove name parameter from QMGR and CMDSERV commands

### DIFF
--- a/src/pymqrest/commands.py
+++ b/src/pymqrest/commands.py
@@ -22,14 +22,13 @@ class MQRESTCommandMixin:
 
     def display_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> dict[str, object] | None:
         objects = self._mqsc_command(
             command="DISPLAY",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -39,14 +38,13 @@ class MQRESTCommandMixin:
 
     def display_qmstatus(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> dict[str, object] | None:
         objects = self._mqsc_command(
             command="DISPLAY",
             mqsc_qualifier="QMSTATUS",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -56,14 +54,13 @@ class MQRESTCommandMixin:
 
     def display_cmdserv(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> dict[str, object] | None:
         objects = self._mqsc_command(
             command="DISPLAY",
             mqsc_qualifier="CMDSERV",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -326,14 +323,13 @@ class MQRESTCommandMixin:
 
     def alter_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="ALTER",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -1460,14 +1456,13 @@ class MQRESTCommandMixin:
 
     def ping_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="PING",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -1530,14 +1525,13 @@ class MQRESTCommandMixin:
 
     def refresh_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="REFRESH",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -1600,14 +1594,13 @@ class MQRESTCommandMixin:
 
     def reset_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="RESET",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -1684,14 +1677,13 @@ class MQRESTCommandMixin:
 
     def resume_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="RESUME",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -1824,14 +1816,13 @@ class MQRESTCommandMixin:
 
     def start_cmdserv(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="START",
             mqsc_qualifier="CMDSERV",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -1852,14 +1843,13 @@ class MQRESTCommandMixin:
 
     def start_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="START",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -1936,14 +1926,13 @@ class MQRESTCommandMixin:
 
     def stop_cmdserv(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="STOP",
             mqsc_qualifier="CMDSERV",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -1978,14 +1967,13 @@ class MQRESTCommandMixin:
 
     def stop_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="STOP",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )
@@ -2034,14 +2022,13 @@ class MQRESTCommandMixin:
 
     def suspend_qmgr(
         self,
-        name: str | None = None,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
         self._mqsc_command(
             command="SUSPEND",
             mqsc_qualifier="QMGR",
-            name=name,
+            name=None,
             request_parameters=request_parameters,
             response_parameters=response_parameters,
         )

--- a/tests/pymqrest/test_session.py
+++ b/tests/pymqrest/test_session.py
@@ -695,10 +695,15 @@ def test_mqsc_command_methods_match_mapping() -> None:
     commands = _load_mqsc_commands()
     assert commands
 
+    nameless_qualifiers = {"QMGR", "QMSTATUS", "CMDSERV"}
     for command in commands:
         method_name = _method_name_from_mqsc(command)
         method = getattr(session, method_name)
-        method(name="TEST.OBJECT")
+        _, qualifier = _split_mqsc_command(command)
+        if qualifier in nameless_qualifiers:
+            method()
+        else:
+            method(name="TEST.OBJECT")
 
     assert len(transport.recorded_requests) == len(commands)
     for recorded_request, command in zip(transport.recorded_requests, commands, strict=True):


### PR DESCRIPTION
## Summary

- Remove the `name` parameter from 13 MQSC command methods (9 QMGR, 1 QMSTATUS, 3 CMDSERV) that operate on the local queue manager implicitly
- Hardcode `name=None` in `_mqsc_command` calls so the JSON payload correctly omits the field
- Update `test_mqsc_command_methods_match_mapping` to call nameless qualifier methods without `name`

Fixes #74

## Test plan

- [x] All 71 unit tests pass
- [x] 100% branch coverage maintained
- [x] Ruff linter passes
- [x] mypy type checker passes
- [ ] CI standards-compliance job passes
- [ ] CI test-and-validate job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)