### PR TITLE
chore: add GitHub Pages deployment workflow for Sphinx docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+name: Docs - Build and Deploy
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: python3 -m pip install uv==0.9.26
+
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-docs-${{ runner.os }}-py3.14-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-docs-${{ runner.os }}-py3.14-
+
+      - name: Install dependencies
+        run: uv sync --frozen --group docs
+
+      - name: Build Sphinx documentation
+        run: uv run sphinx-build -b html docs/sphinx docs/sphinx/_build/html -W
+
+      - name: Upload pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/sphinx/_build/html
+
+  deploy:
+    name: deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Add `docs.yml` workflow for building and deploying Sphinx docs to GitHub Pages
- Build runs on PRs and pushes to develop (sphinx-build -W for warnings as errors)
- Deploy runs only on push to develop via actions/deploy-pages

Note: This was originally part of PR #105 but was lost due to a race between auto-merge and a force-push.

Ref #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)