### PR TITLE
docs: fix autodoc rendering in API reference pages

### DIFF
--- a/docs/sphinx/api/exceptions.md
+++ b/docs/sphinx/api/exceptions.md
@@ -10,21 +10,25 @@ Exception
     └── MQRESTCommandError     — MQSC command failures
 ```
 
-```{autoclass} pymqrest.exceptions.MQRESTError
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: pymqrest.exceptions.MQRESTError
+   :show-inheritance:
 ```
 
-```{autoclass} pymqrest.exceptions.MQRESTTransportError
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: pymqrest.exceptions.MQRESTTransportError
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} pymqrest.exceptions.MQRESTResponseError
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: pymqrest.exceptions.MQRESTResponseError
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} pymqrest.exceptions.MQRESTCommandError
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: pymqrest.exceptions.MQRESTCommandError
+   :members:
+   :show-inheritance:
 ```

--- a/docs/sphinx/api/mapping.md
+++ b/docs/sphinx/api/mapping.md
@@ -6,22 +6,28 @@ for a conceptual overview.
 
 ## Functions
 
-```{autofunction} pymqrest.mapping.map_request_attributes
+```{eval-rst}
+.. autofunction:: pymqrest.mapping.map_request_attributes
 ```
 
-```{autofunction} pymqrest.mapping.map_response_attributes
+```{eval-rst}
+.. autofunction:: pymqrest.mapping.map_response_attributes
 ```
 
-```{autofunction} pymqrest.mapping.map_response_list
+```{eval-rst}
+.. autofunction:: pymqrest.mapping.map_response_list
 ```
 
 ## Diagnostics
 
-```{autoclass} pymqrest.mapping.MappingIssue
-:members:
+```{eval-rst}
+.. autoclass:: pymqrest.mapping.MappingIssue
+   :members:
+   :exclude-members: direction, reason, attribute_name, attribute_value, object_index, qualifier
 ```
 
-```{autoclass} pymqrest.mapping.MappingError
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: pymqrest.mapping.MappingError
+   :members:
+   :show-inheritance:
 ```

--- a/docs/sphinx/api/session.md
+++ b/docs/sphinx/api/session.md
@@ -6,9 +6,10 @@ IBM MQ via the REST API. It inherits all MQSC command methods from
 
 ## MQRESTSession
 
-```{autoclass} pymqrest.session.MQRESTSession
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: pymqrest.session.MQRESTSession
+   :members:
+   :show-inheritance:
 ```
 
 ## Transport
@@ -17,14 +18,17 @@ The transport layer abstracts HTTP communication. The default
 `RequestsTransport` uses the `requests` library. Custom transports
 can be injected for testing or alternative HTTP clients.
 
-```{autoclass} pymqrest.session.TransportResponse
-:members:
+```{eval-rst}
+.. autoclass:: pymqrest.session.TransportResponse
+   :exclude-members: status_code, text, headers
 ```
 
-```{autoclass} pymqrest.session.MQRESTTransport
-:members:
+```{eval-rst}
+.. autoclass:: pymqrest.session.MQRESTTransport
+   :members:
 ```
 
-```{autoclass} pymqrest.session.RequestsTransport
-:members:
+```{eval-rst}
+.. autoclass:: pymqrest.session.RequestsTransport
+   :members:
 ```


### PR DESCRIPTION
## Summary

- Wrap all `autoclass`/`autofunction` directives in `eval-rst` blocks so MyST-parser passes content to the reST parser directly
- Fixes Session, Mapping, and Exceptions API pages which rendered as illegible nested definition lists
- Exclude duplicate dataclass field entries for `TransportResponse` and `MappingIssue`

Fixes #108

## Test plan

- [ ] `sphinx-build -W` succeeds with zero warnings
- [ ] Rendered HTML uses proper `py class`/`py function` elements (no `myst field-list` artifacts)
- [ ] Full validation suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)