### PR TITLE
feat: add idempotent ensure methods for declarative object management

### DIFF
--- a/docs/sphinx/api/ensure.md
+++ b/docs/sphinx/api/ensure.md
@@ -1,0 +1,22 @@
+# Ensure methods
+
+The ensure module provides idempotent object management methods.
+See {doc}`/ensure-methods` for a conceptual overview and usage examples.
+
+## EnsureResult
+
+```{eval-rst}
+.. autoclass:: pymqrest.ensure.EnsureResult
+   :members:
+   :undoc-members:
+   :noindex:
+```
+
+## MQRESTEnsureMixin
+
+```{eval-rst}
+.. autoclass:: pymqrest.ensure.MQRESTEnsureMixin
+   :members:
+   :show-inheritance:
+   :exclude-members: _mqsc_command
+```

--- a/docs/sphinx/api/index.md
+++ b/docs/sphinx/api/index.md
@@ -5,6 +5,7 @@
 
 session
 commands
+ensure
 mapping
 exceptions
 ```

--- a/docs/sphinx/api/session.md
+++ b/docs/sphinx/api/session.md
@@ -1,8 +1,9 @@
 # Session
 
 The `MQRESTSession` class is the main entry point for interacting with
-IBM MQ via the REST API. It inherits all MQSC command methods from
-`MQRESTCommandMixin` (see {doc}`commands`).
+IBM MQ via the REST API. It inherits MQSC command methods from
+`MQRESTCommandMixin` (see {doc}`commands`) and idempotent ensure methods
+from `MQRESTEnsureMixin` (see {doc}`ensure`).
 
 ## MQRESTSession
 

--- a/docs/sphinx/architecture.md
+++ b/docs/sphinx/architecture.md
@@ -14,6 +14,12 @@
   wrapper that calls `_mqsc_command` with the correct command verb and
   qualifier.
 
+**MQRESTEnsureMixin** (`ensure.py`)
+: Provides 15 idempotent `ensure_*` methods for declarative object
+  management. Each method checks current state with DISPLAY, then
+  DEFINE, ALTER, or no-ops as needed. Returns an `EnsureResult` enum.
+  See {doc}`/ensure-methods` for details.
+
 **Mapping pipeline** (`mapping.py`, `mapping_data.py`)
 : Bidirectional attribute translation between Python `snake_case` names
   and native MQSC parameter names. Includes key mapping (attribute names),

--- a/docs/sphinx/ensure-methods.md
+++ b/docs/sphinx/ensure-methods.md
@@ -1,0 +1,161 @@
+# Declarative object management
+
+## The problem with ALTER
+
+Every `alter_*()` call sends an `ALTER` command to the queue manager,
+even when every specified attribute already matches the current state.
+MQ updates `ALTDATE` and `ALTTIME` on every `ALTER`, regardless of
+whether any values actually changed. This makes `ALTER` unsuitable for
+declarative configuration management where idempotency matters — running
+the same configuration twice should not corrupt audit timestamps.
+
+## The ensure pattern
+
+The `ensure_*()` methods implement a declarative upsert pattern:
+
+1. **DEFINE** the object when it does not exist.
+2. **ALTER** only the attributes that differ from the current state.
+3. **Do nothing** when all specified attributes already match,
+   preserving `ALTDATE` and `ALTTIME`.
+
+Each call returns an `EnsureResult` indicating what action was taken:
+
+```python
+from pymqrest import EnsureResult
+
+class EnsureResult(enum.Enum):
+    CREATED = "created"    # Object did not exist, was defined
+    UPDATED = "updated"    # Object existed, attributes were altered
+    UNCHANGED = "unchanged"  # Object existed, no changes needed
+```
+
+## Basic usage
+
+```python
+from pymqrest import MQRESTSession, EnsureResult
+
+session = MQRESTSession(
+    rest_base_url="https://localhost:9443/ibmmq/rest/v2",
+    qmgr_name="QM1",
+    username="mqadmin",
+    password="mqadmin",
+    verify_tls=False,
+)
+
+# First call — queue does not exist yet
+result = session.ensure_qlocal(
+    "APP.REQUEST.Q",
+    request_parameters={
+        "max_q_depth": 50000,
+        "description": "Application request queue",
+    },
+)
+assert result is EnsureResult.CREATED
+
+# Second call — same attributes, nothing to change
+result = session.ensure_qlocal(
+    "APP.REQUEST.Q",
+    request_parameters={
+        "max_q_depth": 50000,
+        "description": "Application request queue",
+    },
+)
+assert result is EnsureResult.UNCHANGED
+
+# Third call — description changed, only that attribute is altered
+result = session.ensure_qlocal(
+    "APP.REQUEST.Q",
+    request_parameters={
+        "max_q_depth": 50000,
+        "description": "Updated request queue",
+    },
+)
+assert result is EnsureResult.UPDATED
+```
+
+## Comparison logic
+
+The ensure methods compare only the attributes the caller passes in
+`request_parameters` against the current state returned by `DISPLAY`.
+Attributes not specified by the caller are ignored.
+
+Comparison is:
+
+- **Case-insensitive** — `"ENABLED"` matches `"enabled"`.
+- **Type-normalizing** — integer `5000` matches string `"5000"`.
+- **Whitespace-trimming** — `" YES "` matches `"YES"`.
+
+An attribute present in `request_parameters` but absent from the
+`DISPLAY` response is treated as changed and included in the `ALTER`.
+
+## Selective ALTER
+
+When an update is needed, only the changed attributes are sent in the
+`ALTER` command. Attributes that already match are excluded from the
+request. This minimizes the scope of each `ALTER` to the strict delta.
+
+## Available methods
+
+Each method targets a specific MQ object type with the correct
+MQSC qualifier triple (DISPLAY / DEFINE / ALTER):
+
+| Method | Object type | DISPLAY | DEFINE | ALTER |
+| --- | --- | --- | --- | --- |
+| `ensure_qlocal()` | Local queue | `QUEUE` | `QLOCAL` | `QLOCAL` |
+| `ensure_qremote()` | Remote queue | `QUEUE` | `QREMOTE` | `QREMOTE` |
+| `ensure_qalias()` | Alias queue | `QUEUE` | `QALIAS` | `QALIAS` |
+| `ensure_qmodel()` | Model queue | `QUEUE` | `QMODEL` | `QMODEL` |
+| `ensure_channel()` | Channel | `CHANNEL` | `CHANNEL` | `CHANNEL` |
+| `ensure_authinfo()` | Auth info | `AUTHINFO` | `AUTHINFO` | `AUTHINFO` |
+| `ensure_listener()` | Listener | `LISTENER` | `LISTENER` | `LISTENER` |
+| `ensure_namelist()` | Namelist | `NAMELIST` | `NAMELIST` | `NAMELIST` |
+| `ensure_process()` | Process | `PROCESS` | `PROCESS` | `PROCESS` |
+| `ensure_service()` | Service | `SERVICE` | `SERVICE` | `SERVICE` |
+| `ensure_topic()` | Topic | `TOPIC` | `TOPIC` | `TOPIC` |
+| `ensure_sub()` | Subscription | `SUB` | `SUB` | `SUB` |
+| `ensure_stgclass()` | Storage class | `STGCLASS` | `STGCLASS` | `STGCLASS` |
+| `ensure_comminfo()` | Comm info | `COMMINFO` | `COMMINFO` | `COMMINFO` |
+| `ensure_cfstruct()` | CF structure | `CFSTRUCT` | `CFSTRUCT` | `CFSTRUCT` |
+
+All methods share the same signature:
+
+```python
+def ensure_qlocal(
+    self,
+    name: str,
+    request_parameters: Mapping[str, object] | None = None,
+) -> EnsureResult:
+```
+
+`response_parameters` is not exposed — the ensure logic always requests
+`["all"]` internally so it can compare the full current state.
+
+## Attribute mapping
+
+The ensure methods participate in the same
+{doc}`mapping pipeline </mapping-pipeline>` as all other command methods.
+Pass `snake_case` attribute names in `request_parameters` and the
+mapping layer translates them to MQSC names for the DISPLAY, DEFINE,
+and ALTER commands automatically.
+
+## Configuration management example
+
+The ensure pattern is designed for scripts that declare desired state:
+
+```python
+def configure_application_queues(session):
+    """Ensure all application queues exist with correct settings."""
+    queues = {
+        "APP.REQUEST.Q": {"max_q_depth": 50000, "def_persistence": "yes"},
+        "APP.REPLY.Q": {"max_q_depth": 10000, "def_persistence": "no"},
+        "APP.DLQ": {"max_q_depth": 100000, "def_persistence": "yes"},
+    }
+
+    for name, attrs in queues.items():
+        result = session.ensure_qlocal(name, request_parameters=attrs)
+        print(f"{name}: {result.value}")
+```
+
+Running this script repeatedly produces no side effects when the
+configuration is already correct. Only genuine changes trigger `ALTER`
+commands, keeping `ALTDATE`/`ALTTIME` accurate.

--- a/docs/sphinx/index.md
+++ b/docs/sphinx/index.md
@@ -13,6 +13,7 @@ and error propagation.
 :caption: User Guide
 
 getting-started
+ensure-methods
 examples
 architecture
 mapping-pipeline

--- a/src/pymqrest/__init__.py
+++ b/src/pymqrest/__init__.py
@@ -1,5 +1,6 @@
 """pymqrest runtime package."""
 
+from .ensure import EnsureResult
 from .exceptions import (
     MQRESTCommandError,
     MQRESTError,
@@ -16,6 +17,7 @@ from .mapping import (
 from .session import MQRESTSession
 
 __all__ = [
+    "EnsureResult",
     "MQRESTCommandError",
     "MQRESTError",
     "MQRESTResponseError",

--- a/src/pymqrest/ensure.py
+++ b/src/pymqrest/ensure.py
@@ -1,0 +1,468 @@
+"""Idempotent ensure methods for MQ object management."""
+
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+class EnsureResult(enum.Enum):
+    """Result of an ensure operation.
+
+    Attributes:
+        CREATED: The object did not exist and was defined.
+        UPDATED: The object existed but attributes differed and were altered.
+        UNCHANGED: The object existed and all specified attributes already matched.
+
+    """
+
+    CREATED = "created"
+    UPDATED = "updated"
+    UNCHANGED = "unchanged"
+
+
+class MQRESTEnsureMixin:
+    """Mixin providing idempotent ensure methods for MQ objects.
+
+    Each ``ensure_*`` method implements a declarative upsert pattern:
+    DEFINE when the object does not exist, ALTER only when specified
+    attributes differ, and no-op when they already match — preserving
+    ``ALTDATE``/``ALTTIME`` for unchanged objects.
+    """
+
+    def _mqsc_command(  # noqa: PLR0913
+        self,
+        *,
+        command: str,
+        mqsc_qualifier: str,
+        name: str | None,
+        request_parameters: Mapping[str, object] | None,
+        response_parameters: Sequence[str] | None,
+        where: str | None = None,
+    ) -> list[dict[str, object]]:
+        raise NotImplementedError  # pragma: no cover
+
+    def _ensure_object(
+        self,
+        *,
+        name: str,
+        request_parameters: Mapping[str, object] | None,
+        display_qualifier: str,
+        define_qualifier: str,
+        alter_qualifier: str,
+    ) -> EnsureResult:
+        """Core ensure logic shared by all ``ensure_*`` methods.
+
+        Args:
+            name: MQ object name.
+            request_parameters: Desired attributes to assert/set.
+            display_qualifier: MQSC qualifier for the DISPLAY command.
+            define_qualifier: MQSC qualifier for the DEFINE command.
+            alter_qualifier: MQSC qualifier for the ALTER command.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        current_objects = self._mqsc_command(
+            command="DISPLAY",
+            mqsc_qualifier=display_qualifier,
+            name=name,
+            request_parameters=None,
+            response_parameters=["all"],
+        )
+
+        params = dict(request_parameters) if request_parameters else {}
+
+        if not current_objects:
+            self._mqsc_command(
+                command="DEFINE",
+                mqsc_qualifier=define_qualifier,
+                name=name,
+                request_parameters=params or None,
+                response_parameters=None,
+            )
+            return EnsureResult.CREATED
+
+        if not params:
+            return EnsureResult.UNCHANGED
+
+        current = current_objects[0]
+        changed: dict[str, object] = {}
+        for key, desired_value in params.items():
+            current_value = current.get(key)
+            if not _values_match(desired_value, current_value):
+                changed[key] = desired_value
+
+        if not changed:
+            return EnsureResult.UNCHANGED
+
+        self._mqsc_command(
+            command="ALTER",
+            mqsc_qualifier=alter_qualifier,
+            name=name,
+            request_parameters=changed,
+            response_parameters=None,
+        )
+        return EnsureResult.UPDATED
+
+    def ensure_qlocal(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a local queue exists with the specified attributes.
+
+        Args:
+            name: Queue name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="QUEUE",
+            define_qualifier="QLOCAL",
+            alter_qualifier="QLOCAL",
+        )
+
+    def ensure_qremote(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a remote queue exists with the specified attributes.
+
+        Args:
+            name: Queue name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="QUEUE",
+            define_qualifier="QREMOTE",
+            alter_qualifier="QREMOTE",
+        )
+
+    def ensure_qalias(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure an alias queue exists with the specified attributes.
+
+        Args:
+            name: Queue name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="QUEUE",
+            define_qualifier="QALIAS",
+            alter_qualifier="QALIAS",
+        )
+
+    def ensure_qmodel(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a model queue exists with the specified attributes.
+
+        Args:
+            name: Queue name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="QUEUE",
+            define_qualifier="QMODEL",
+            alter_qualifier="QMODEL",
+        )
+
+    def ensure_channel(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a channel exists with the specified attributes.
+
+        Args:
+            name: Channel name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="CHANNEL",
+            define_qualifier="CHANNEL",
+            alter_qualifier="CHANNEL",
+        )
+
+    def ensure_authinfo(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure an authentication information object exists with the specified attributes.
+
+        Args:
+            name: Authentication information object name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="AUTHINFO",
+            define_qualifier="AUTHINFO",
+            alter_qualifier="AUTHINFO",
+        )
+
+    def ensure_listener(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a listener exists with the specified attributes.
+
+        Args:
+            name: Listener name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="LISTENER",
+            define_qualifier="LISTENER",
+            alter_qualifier="LISTENER",
+        )
+
+    def ensure_namelist(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a namelist exists with the specified attributes.
+
+        Args:
+            name: Namelist name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="NAMELIST",
+            define_qualifier="NAMELIST",
+            alter_qualifier="NAMELIST",
+        )
+
+    def ensure_process(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a process exists with the specified attributes.
+
+        Args:
+            name: Process name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="PROCESS",
+            define_qualifier="PROCESS",
+            alter_qualifier="PROCESS",
+        )
+
+    def ensure_service(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a service exists with the specified attributes.
+
+        Args:
+            name: Service name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="SERVICE",
+            define_qualifier="SERVICE",
+            alter_qualifier="SERVICE",
+        )
+
+    def ensure_topic(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a topic exists with the specified attributes.
+
+        Args:
+            name: Topic name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="TOPIC",
+            define_qualifier="TOPIC",
+            alter_qualifier="TOPIC",
+        )
+
+    def ensure_sub(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a subscription exists with the specified attributes.
+
+        Args:
+            name: Subscription name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="SUB",
+            define_qualifier="SUB",
+            alter_qualifier="SUB",
+        )
+
+    def ensure_stgclass(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a storage class exists with the specified attributes.
+
+        Args:
+            name: Storage class name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="STGCLASS",
+            define_qualifier="STGCLASS",
+            alter_qualifier="STGCLASS",
+        )
+
+    def ensure_comminfo(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a communication information object exists with the specified attributes.
+
+        Args:
+            name: Communication information object name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="COMMINFO",
+            define_qualifier="COMMINFO",
+            alter_qualifier="COMMINFO",
+        )
+
+    def ensure_cfstruct(
+        self,
+        name: str,
+        request_parameters: Mapping[str, object] | None = None,
+    ) -> EnsureResult:
+        """Ensure a CF structure exists with the specified attributes.
+
+        Args:
+            name: CF structure name.
+            request_parameters: Desired attributes to assert/set.
+
+        Returns:
+            The :class:`EnsureResult` indicating what action was taken.
+
+        """
+        return self._ensure_object(
+            name=name,
+            request_parameters=request_parameters,
+            display_qualifier="CFSTRUCT",
+            define_qualifier="CFSTRUCT",
+            alter_qualifier="CFSTRUCT",
+        )
+
+
+def _values_match(desired: object, current: object) -> bool:
+    """Compare desired and current attribute values.
+
+    Normalizes both sides to strings for comparison, since the MQ REST
+    API returns string values but callers may pass int or str.
+    Case-insensitive string comparison is used because MQ attribute
+    values are case-insensitive.
+    """
+    if current is None:
+        return False
+    return str(desired).strip().upper() == str(current).strip().upper()

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -12,6 +12,7 @@ import requests
 from requests import RequestException
 
 from .commands import MQRESTCommandMixin
+from .ensure import MQRESTEnsureMixin
 from .exceptions import (
     MQRESTCommandError,
     MQRESTResponseError,
@@ -145,7 +146,7 @@ class RequestsTransport:
         )
 
 
-class MQRESTSession(MQRESTCommandMixin):
+class MQRESTSession(MQRESTEnsureMixin, MQRESTCommandMixin):
     """Session wrapper for MQ REST admin calls.
 
     Provides MQSC command execution via the IBM MQ ``runCommandJSON``

--- a/tests/pymqrest/test_ensure.py
+++ b/tests/pymqrest/test_ensure.py
@@ -1,0 +1,390 @@
+"""Tests for idempotent ensure methods."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pymqrest.ensure import EnsureResult, _values_match
+from pymqrest.session import MQRESTSession, TransportResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+TEST_PASSWORD = "pass"  # noqa: S105
+EXPECT_ONE_REQUEST = 1
+EXPECT_TWO_REQUESTS = 2
+
+
+@dataclass(frozen=True)
+class RecordedRequest:
+    """Captured request for assertion."""
+
+    url: str
+    payload: dict[str, object]
+    headers: dict[str, str]
+    timeout_seconds: float | None
+    verify_tls: bool
+
+
+class MultiResponseTransport:
+    """Transport that returns a sequence of canned responses."""
+
+    def __init__(self, responses: Sequence[TransportResponse]) -> None:
+        self._responses = list(responses)
+        self._call_index = 0
+        self.recorded_requests: list[RecordedRequest] = []
+
+    def post_json(
+        self,
+        url: str,
+        payload: Mapping[str, object],
+        *,
+        headers: Mapping[str, str],
+        timeout_seconds: float | None,
+        verify_tls: bool,
+    ) -> TransportResponse:
+        self.recorded_requests.append(
+            RecordedRequest(
+                url=url,
+                payload=dict(payload),
+                headers=dict(headers),
+                timeout_seconds=timeout_seconds,
+                verify_tls=verify_tls,
+            ),
+        )
+        response = self._responses[self._call_index]
+        self._call_index += 1
+        return response
+
+
+def _make_response(payload: dict[str, object]) -> TransportResponse:
+    return TransportResponse(status_code=200, text=json.dumps(payload), headers={})
+
+
+def _success_payload(
+    parameters: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    if parameters is None:
+        return {
+            "overallCompletionCode": 0,
+            "overallReasonCode": 0,
+        }
+    return {
+        "commandResponse": [{"completionCode": 0, "reasonCode": 0, "parameters": p} for p in parameters],
+        "overallCompletionCode": 0,
+        "overallReasonCode": 0,
+    }
+
+
+def _build_session(
+    responses: Sequence[dict[str, object]],
+    *,
+    mapping_strict: bool | None = None,
+) -> tuple[MQRESTSession, MultiResponseTransport]:
+    transport = MultiResponseTransport([_make_response(r) for r in responses])
+    kwargs: dict[str, object] = {
+        "rest_base_url": "https://example.invalid/ibmmq/rest/v2",
+        "qmgr_name": "QM1",
+        "username": "user",
+        "password": TEST_PASSWORD,
+        "transport": transport,
+    }
+    if mapping_strict is not None:
+        kwargs["mapping_strict"] = mapping_strict
+    session = MQRESTSession(**kwargs)  # type: ignore[arg-type]
+    return session, transport
+
+
+# ---------------------------------------------------------------------------
+# EnsureResult enum
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureResult:
+    def test_values(self) -> None:
+        assert EnsureResult.CREATED.value == "created"
+        assert EnsureResult.UPDATED.value == "updated"
+        assert EnsureResult.UNCHANGED.value == "unchanged"
+
+    def test_members(self) -> None:
+        assert set(EnsureResult) == {
+            EnsureResult.CREATED,
+            EnsureResult.UPDATED,
+            EnsureResult.UNCHANGED,
+        }
+
+
+# ---------------------------------------------------------------------------
+# _values_match helper
+# ---------------------------------------------------------------------------
+
+
+class TestValuesMatch:
+    def test_string_match(self) -> None:
+        assert _values_match("ENABLED", "ENABLED") is True
+
+    def test_case_insensitive(self) -> None:
+        assert _values_match("ENABLED", "enabled") is True
+        assert _values_match("enabled", "ENABLED") is True
+
+    def test_int_string_match(self) -> None:
+        assert _values_match(5, "5") is True
+        assert _values_match("5", 5) is True
+
+    def test_whitespace_stripped(self) -> None:
+        assert _values_match("YES", " YES ") is True
+
+    def test_mismatch(self) -> None:
+        assert _values_match("YES", "NO") is False
+
+    def test_current_none(self) -> None:
+        assert _values_match("YES", None) is False
+
+
+# ---------------------------------------------------------------------------
+# Object does not exist -> CREATED
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCreated:
+    def test_object_not_found_creates(self) -> None:
+        display_response = _success_payload()  # empty commandResponse
+        define_response = _success_payload()
+        session, transport = _build_session([display_response, define_response])
+
+        result = session.ensure_qlocal("TEST.Q", request_parameters={"description": "test"})
+
+        assert result is EnsureResult.CREATED
+        assert len(transport.recorded_requests) == EXPECT_TWO_REQUESTS
+        define_payload = transport.recorded_requests[1].payload
+        assert define_payload["command"] == "DEFINE"
+        assert define_payload["qualifier"] == "QLOCAL"
+        assert define_payload["name"] == "TEST.Q"
+
+    def test_object_not_found_no_params_creates(self) -> None:
+        display_response = _success_payload()
+        define_response = _success_payload()
+        session, transport = _build_session([display_response, define_response])
+
+        result = session.ensure_qlocal("TEST.Q")
+
+        assert result is EnsureResult.CREATED
+        assert len(transport.recorded_requests) == EXPECT_TWO_REQUESTS
+        define_payload = transport.recorded_requests[1].payload
+        assert define_payload["command"] == "DEFINE"
+        assert "parameters" not in define_payload
+
+
+# ---------------------------------------------------------------------------
+# Object exists, attributes match -> UNCHANGED
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureUnchanged:
+    def test_attributes_match_exact(self) -> None:
+        # Raw MQSC response uses DESCR; mapping converts to description.
+        display_response = _success_payload([{"DESCR": "test"}])
+        session, transport = _build_session([display_response])
+
+        result = session.ensure_qlocal("TEST.Q", request_parameters={"description": "test"})
+
+        assert result is EnsureResult.UNCHANGED
+        assert len(transport.recorded_requests) == EXPECT_ONE_REQUEST
+
+    def test_case_insensitive_match(self) -> None:
+        display_response = _success_payload([{"DESCR": "TEST"}])
+        session, transport = _build_session([display_response])
+
+        result = session.ensure_qlocal("TEST.Q", request_parameters={"description": "test"})
+
+        assert result is EnsureResult.UNCHANGED
+        assert len(transport.recorded_requests) == EXPECT_ONE_REQUEST
+
+    def test_int_string_match(self) -> None:
+        display_response = _success_payload([{"MAXDEPTH": "5000"}])
+        session, transport = _build_session([display_response])
+
+        result = session.ensure_qlocal("TEST.Q", request_parameters={"max_q_depth": 5000})
+
+        assert result is EnsureResult.UNCHANGED
+        assert len(transport.recorded_requests) == EXPECT_ONE_REQUEST
+
+    def test_no_request_parameters(self) -> None:
+        display_response = _success_payload([{"DESCR": "existing"}])
+        session, transport = _build_session([display_response])
+
+        result = session.ensure_qlocal("TEST.Q")
+
+        assert result is EnsureResult.UNCHANGED
+        assert len(transport.recorded_requests) == EXPECT_ONE_REQUEST
+
+    def test_empty_request_parameters(self) -> None:
+        display_response = _success_payload([{"DESCR": "existing"}])
+        session, transport = _build_session([display_response])
+
+        result = session.ensure_qlocal("TEST.Q", request_parameters={})
+
+        assert result is EnsureResult.UNCHANGED
+        assert len(transport.recorded_requests) == EXPECT_ONE_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# Object exists, attributes differ -> UPDATED
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureUpdated:
+    def test_attributes_differ_alters(self) -> None:
+        display_response = _success_payload([{"DESCR": "old"}])
+        alter_response = _success_payload()
+        session, transport = _build_session([display_response, alter_response])
+
+        result = session.ensure_qlocal("TEST.Q", request_parameters={"description": "new"})
+
+        assert result is EnsureResult.UPDATED
+        assert len(transport.recorded_requests) == EXPECT_TWO_REQUESTS
+        alter_payload = transport.recorded_requests[1].payload
+        assert alter_payload["command"] == "ALTER"
+        assert alter_payload["qualifier"] == "QLOCAL"
+        assert alter_payload["name"] == "TEST.Q"
+
+    def test_only_changed_attributes_sent(self) -> None:
+        display_response = _success_payload([{"DESCR": "old", "MAXDEPTH": "5000"}])
+        alter_response = _success_payload()
+        session, transport = _build_session([display_response, alter_response])
+
+        result = session.ensure_qlocal(
+            "TEST.Q",
+            request_parameters={"description": "new", "max_q_depth": 5000},
+        )
+
+        assert result is EnsureResult.UPDATED
+        alter_payload = transport.recorded_requests[1].payload
+        # max_q_depth matches (5000 == "5000"), so only description should be sent.
+        assert alter_payload["parameters"] == {"DESCR": "new"}
+
+    def test_missing_attribute_treated_as_changed(self) -> None:
+        display_response = _success_payload([{"DESCR": "test"}])
+        alter_response = _success_payload()
+        session, _transport = _build_session([display_response, alter_response])
+
+        result = session.ensure_qlocal(
+            "TEST.Q",
+            request_parameters={"description": "test", "max_q_depth": 5000},
+        )
+
+        assert result is EnsureResult.UPDATED
+
+
+# ---------------------------------------------------------------------------
+# Display command verification
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayCommand:
+    def test_display_uses_correct_qualifier(self) -> None:
+        display_response = _success_payload()
+        define_response = _success_payload()
+        session, transport = _build_session([display_response, define_response])
+
+        session.ensure_qlocal("TEST.Q")
+
+        display_payload = transport.recorded_requests[0].payload
+        assert display_payload["command"] == "DISPLAY"
+        assert display_payload["qualifier"] == "QUEUE"
+        assert display_payload["responseParameters"] == ["all"]
+
+    def test_display_requests_all_attributes(self) -> None:
+        display_response = _success_payload()
+        define_response = _success_payload()
+        session, transport = _build_session([display_response, define_response])
+
+        session.ensure_channel("TEST.CHL")
+
+        display_payload = transport.recorded_requests[0].payload
+        assert display_payload["responseParameters"] == ["all"]
+
+
+# ---------------------------------------------------------------------------
+# Each ensure method uses correct qualifier triple
+# ---------------------------------------------------------------------------
+
+
+_QUALIFIER_TRIPLES = [
+    ("ensure_qlocal", "QUEUE", "QLOCAL", "QLOCAL"),
+    ("ensure_qremote", "QUEUE", "QREMOTE", "QREMOTE"),
+    ("ensure_qalias", "QUEUE", "QALIAS", "QALIAS"),
+    ("ensure_qmodel", "QUEUE", "QMODEL", "QMODEL"),
+    ("ensure_channel", "CHANNEL", "CHANNEL", "CHANNEL"),
+    ("ensure_authinfo", "AUTHINFO", "AUTHINFO", "AUTHINFO"),
+    ("ensure_listener", "LISTENER", "LISTENER", "LISTENER"),
+    ("ensure_namelist", "NAMELIST", "NAMELIST", "NAMELIST"),
+    ("ensure_process", "PROCESS", "PROCESS", "PROCESS"),
+    ("ensure_service", "SERVICE", "SERVICE", "SERVICE"),
+    ("ensure_topic", "TOPIC", "TOPIC", "TOPIC"),
+    ("ensure_sub", "SUB", "SUB", "SUB"),
+    ("ensure_stgclass", "STGCLASS", "STGCLASS", "STGCLASS"),
+    ("ensure_comminfo", "COMMINFO", "COMMINFO", "COMMINFO"),
+    ("ensure_cfstruct", "CFSTRUCT", "CFSTRUCT", "CFSTRUCT"),
+]
+
+
+class TestQualifierTriples:
+    @pytest.mark.parametrize(
+        ("method_name", "display_q", "define_q", "alter_q"),
+        _QUALIFIER_TRIPLES,
+        ids=[t[0] for t in _QUALIFIER_TRIPLES],
+    )
+    def test_create_uses_correct_qualifiers(
+        self,
+        method_name: str,
+        display_q: str,
+        define_q: str,
+        alter_q: str,  # noqa: ARG002
+    ) -> None:
+        display_response = _success_payload()
+        define_response = _success_payload()
+        session, transport = _build_session([display_response, define_response])
+
+        method = getattr(session, method_name)
+        result = method("TEST.OBJ")
+
+        assert result is EnsureResult.CREATED
+        display_payload = transport.recorded_requests[0].payload
+        assert display_payload["qualifier"] == display_q
+        define_payload = transport.recorded_requests[1].payload
+        assert define_payload["qualifier"] == define_q
+
+    @pytest.mark.parametrize(
+        ("method_name", "display_q", "define_q", "alter_q"),
+        _QUALIFIER_TRIPLES,
+        ids=[t[0] for t in _QUALIFIER_TRIPLES],
+    )
+    def test_update_uses_correct_qualifiers(
+        self,
+        method_name: str,
+        display_q: str,
+        define_q: str,  # noqa: ARG002
+        alter_q: str,
+    ) -> None:
+        # Use DESCR (valid MQSC attr) and lenient mapping so qualifiers
+        # without full mapping entries don't raise.
+        display_response = _success_payload([{"DESCR": "old"}])
+        alter_response = _success_payload()
+        session, transport = _build_session(
+            [display_response, alter_response],
+            mapping_strict=False,
+        )
+
+        method = getattr(session, method_name)
+        result = method("TEST.OBJ", request_parameters={"description": "new"})
+
+        assert result is EnsureResult.UPDATED
+        display_payload = transport.recorded_requests[0].payload
+        assert display_payload["qualifier"] == display_q
+        alter_payload = transport.recorded_requests[1].payload
+        assert alter_payload["qualifier"] == alter_q


### PR DESCRIPTION
## Summary

- Add `ensure_*()` methods implementing a declarative upsert pattern: DEFINE when missing, ALTER only changed attributes, no-op when matching — preserving `ALTDATE`/`ALTTIME` for unchanged objects
- New `EnsureResult` enum (`CREATED`, `UPDATED`, `UNCHANGED`) returned by all 15 ensure methods covering queues, channels, listeners, topics, namelists, processes, services, subscriptions, storage classes, auth info, comm info, and CF structures
- Sphinx documentation: dedicated User Guide page ("Declarative object management") positioned prominently after Getting Started, plus API Reference page with autodoc

Fixes #75

## Test plan

- [ ] Unit tests pass: `uv run pytest tests/pymqrest/test_ensure.py` (50 tests, 100% coverage)
- [ ] Full suite passes: `uv run pytest --cov=pymqrest --cov-branch --cov-fail-under=100`
- [ ] Ruff, mypy, ty all pass: `uv run python3 scripts/dev/validate_local.py`
- [ ] Sphinx build clean: `uv run python3 -m sphinx -b html docs/sphinx docs/sphinx/_build/html -W`
- [ ] Integration tests with live QM: `PYMQREST_RUN_INTEGRATION=1 uv run pytest -m integration -k ensure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)