### PR TITLE
feat: add ensure_qmgr for idempotent queue manager attribute management

### DIFF
--- a/docs/sphinx/architecture.md
+++ b/docs/sphinx/architecture.md
@@ -15,9 +15,10 @@
   qualifier.
 
 **MQRESTEnsureMixin** (`ensure.py`)
-: Provides 15 idempotent `ensure_*` methods for declarative object
+: Provides 16 idempotent `ensure_*` methods for declarative object
   management. Each method checks current state with DISPLAY, then
   DEFINE, ALTER, or no-ops as needed. Returns an `EnsureResult` enum.
+  `ensure_qmgr()` is a special singleton variant (no name, no DEFINE).
   See {doc}`/ensure-methods` for details.
 
 **Mapping pipeline** (`mapping.py`, `mapping_data.py`)

--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -405,6 +405,29 @@ def test_mutating_object_lifecycle(case: LifecycleCase) -> None:
     assert not _display_contains_value(deleted_result, case.object_name)
 
 
+def test_ensure_qmgr_lifecycle() -> None:
+    config = load_integration_config()
+    session = _build_session(config)
+
+    # Read current description so we can restore it.
+    qmgr = session.display_qmgr()
+    assert qmgr is not None
+    original_descr = qmgr.get("description", "")
+
+    test_descr = "pymqrest ensure_qmgr test"
+
+    # Alter to test value.
+    result = session.ensure_qmgr(request_parameters={"description": test_descr})
+    assert result in {EnsureResult.UPDATED, EnsureResult.UNCHANGED}
+
+    # Unchanged (same attributes).
+    result = session.ensure_qmgr(request_parameters={"description": test_descr})
+    assert result is EnsureResult.UNCHANGED
+
+    # Restore original description.
+    session.ensure_qmgr(request_parameters={"description": original_descr})
+
+
 def test_ensure_qlocal_lifecycle() -> None:
     config = load_integration_config()
     session = _build_session(config)


### PR DESCRIPTION
## Summary

- Add `ensure_qmgr()` singleton variant: no `name` param, no DEFINE path, returns `UPDATED` or `UNCHANGED` (never `CREATED`)
- Short-circuits to `UNCHANGED` when no `request_parameters` provided (skips DISPLAY entirely)
- 6 new unit tests covering match, diff, selective ALTER, no-params, empty-params, and empty-DISPLAY edge case
- Integration test with save/restore of original QMGR description
- Docs: updated methods table, added singleton signature section, enriched config management example with `ensure_qmgr` usage

## Test plan

- [x] `uv run pytest --cov=pymqrest --cov-report=term-missing --cov-branch --cov-fail-under=100` — 147 passed, 100% coverage
- [x] `uv run python3 scripts/dev/validate_local.py` — all checks passed
- [ ] CI pipeline (ruff, mypy, ty, pytest, docs, standards)
- [ ] Integration: `PYMQREST_RUN_INTEGRATION=1 uv run pytest -m integration -k ensure_qmgr`

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)