### PR TITLE
chore: align codebase with canonical coding standards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,21 @@
 # Pull Request
 
 ## Summary
-- 
+
+-
 
 ## Issue Linkage
+
 - Fixes # (default; use when no acceptance criteria exist)
 - Ref # (use when acceptance criteria exist)
 - Work is not complete until the issue is closed.
 - If no issue exists, open one before any work begins.
 
 ## Testing
-- python3 scripts/dev/validate_local.py
+
+- markdownlint
+- uv run python3 scripts/dev/validate_local.py
 
 ## Notes
-- 
+
+-

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -9,6 +9,7 @@
 - [Linting policy](#linting-policy)
 - [Python invocation](#python-invocation)
 - [Tooling requirement](#tooling-requirement)
+- [Merge strategy override](#merge-strategy-override)
 - [Temporary tooling workaround](#temporary-tooling-workaround)
 
 ## Pre-flight checklist
@@ -48,7 +49,19 @@
 
 ## Tooling requirement
 
-- `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`).
+Required for daily workflow:
+
+- `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`)
+- `markdownlint` (required for docs validation and PR pre-submission)
+
+Required for integration testing:
+
+- Docker (for local MQ container environment)
+
+## Merge strategy override
+
+- This repository uses squash merges (`--squash`) instead of the canonical default (`--merge`).
+- Use `gh pr merge --auto --squash --delete-branch` for auto-merge.
 
 ## Temporary tooling workaround
 

--- a/scripts/dev/generate_commands.py
+++ b/scripts/dev/generate_commands.py
@@ -73,7 +73,7 @@ def load_mapping_data() -> dict[str, object]:
 def available_mapping_pages() -> frozenset[str]:
     if not MAPPINGS_DIR.is_dir():
         return frozenset()
-    return frozenset(p.stem for p in MAPPINGS_DIR.iterdir() if p.suffix == ".md" and p.stem != "index")
+    return frozenset(path.stem for path in MAPPINGS_DIR.iterdir() if path.suffix == ".md" and path.stem != "index")
 
 
 def _build_args_section(cmd: CommandSpec) -> list[str]:

--- a/src/pymqrest/__init__.py
+++ b/src/pymqrest/__init__.py
@@ -1,5 +1,7 @@
 """pymqrest runtime package."""
 
+from importlib.metadata import version
+
 from .ensure import EnsureResult
 from .exceptions import (
     MQRESTCommandError,
@@ -16,6 +18,8 @@ from .mapping import (
 )
 from .session import MQRESTSession
 
+__version__ = version("pymqrest")
+
 __all__ = [
     "EnsureResult",
     "MQRESTCommandError",
@@ -25,6 +29,7 @@ __all__ = [
     "MQRESTTransportError",
     "MappingError",
     "MappingIssue",
+    "__version__",
     "map_request_attributes",
     "map_response_attributes",
     "map_response_list",

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -419,7 +419,7 @@ def _flatten_nested_objects(
     for item in parameter_objects:
         objects = item.get("objects")
         if isinstance(objects, list):
-            shared = {k: v for k, v in item.items() if k != "objects"}
+            shared = {key: value for key, value in item.items() if key != "objects"}
             for nested_item in objects:
                 if isinstance(nested_item, Mapping):
                     merged = dict(shared)
@@ -561,7 +561,7 @@ def _build_snake_to_mqsc_map(qualifier_entry: Mapping[str, object]) -> dict[str,
                 response_lookup.setdefault(snake_key, mqsc_key)
     combined_map = dict(response_lookup)
     if isinstance(request_key_map, Mapping):
-        combined_map.update({k: v for k, v in request_key_map.items() if isinstance(v, str)})
+        combined_map.update({key: value for key, value in request_key_map.items() if isinstance(value, str)})
     return combined_map
 
 

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -69,7 +69,7 @@ def test_queue_depth_monitor() -> None:
     results = monitor_queue_depths(session)
 
     assert len(results) > 0
-    names = [q.name for q in results]
+    names = [result.name for result in results]
     assert any("PYMQREST" in name for name in names)
 
 
@@ -79,7 +79,7 @@ def test_channel_status_report() -> None:
     results = report_channel_status(session)
 
     assert len(results) > 0
-    names = [c.name for c in results]
+    names = [result.name for result in results]
     assert "PYMQREST.SVRCONN" in names
 
 
@@ -104,4 +104,4 @@ def test_provision_and_teardown() -> None:
     assert result.verified is True
 
     failures = teardown(qm1, qm2)
-    assert failures == [] or all("not found" not in f.lower() for f in failures)
+    assert failures == [] or all("not found" not in msg.lower() for msg in failures)

--- a/tests/pymqrest/test_ensure.py
+++ b/tests/pymqrest/test_ensure.py
@@ -74,7 +74,7 @@ def _success_payload(
             "overallReasonCode": 0,
         }
     return {
-        "commandResponse": [{"completionCode": 0, "reasonCode": 0, "parameters": p} for p in parameters],
+        "commandResponse": [{"completionCode": 0, "reasonCode": 0, "parameters": params} for params in parameters],
         "overallCompletionCode": 0,
         "overallReasonCode": 0,
     }
@@ -85,7 +85,7 @@ def _build_session(
     *,
     mapping_strict: bool | None = None,
 ) -> tuple[MQRESTSession, MultiResponseTransport]:
-    transport = MultiResponseTransport([_make_response(r) for r in responses])
+    transport = MultiResponseTransport([_make_response(resp) for resp in responses])
     kwargs: dict[str, object] = {
         "rest_base_url": "https://example.invalid/ibmmq/rest/v2",
         "qmgr_name": "QM1",
@@ -431,7 +431,7 @@ class TestQualifierTriples:
     @pytest.mark.parametrize(
         ("method_name", "display_q", "define_q", "alter_q"),
         _QUALIFIER_TRIPLES,
-        ids=[t[0] for t in _QUALIFIER_TRIPLES],
+        ids=[triple[0] for triple in _QUALIFIER_TRIPLES],
     )
     def test_create_uses_correct_qualifiers(
         self,
@@ -456,7 +456,7 @@ class TestQualifierTriples:
     @pytest.mark.parametrize(
         ("method_name", "display_q", "define_q", "alter_q"),
         _QUALIFIER_TRIPLES,
-        ids=[t[0] for t in _QUALIFIER_TRIPLES],
+        ids=[triple[0] for triple in _QUALIFIER_TRIPLES],
     )
     def test_update_uses_correct_qualifiers(
         self,


### PR DESCRIPTION
## Summary

- Rename single-character loop variables (`k`, `v`, `p`, `r`, `t`, `q`, `c`, `f`) to 3+ character descriptive names per naming conventions standard
- Add runtime `__version__` via `importlib.metadata.version()` per library versioning standard
- Fix PR template: add `markdownlint`, use `uv run python3`, fix markdownlint violations
- Document squash merge override and categorized external tooling list in repository standards

## Issue Linkage

- Fixes #120

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)