### PR TITLE
feat: add LTPA token and mTLS client certificate authentication

### DIFF
--- a/docs/sphinx/api/auth.md
+++ b/docs/sphinx/api/auth.md
@@ -1,0 +1,54 @@
+# Authentication
+
+The authentication module provides credential types for the three
+authentication modes supported by the IBM MQ REST API: HTTP Basic,
+LTPA token, and mutual TLS (mTLS) client certificates.
+
+Pass a credential object to `MQRESTSession` via the `credentials`
+keyword argument, or use the positional `username`/`password`
+shorthand for Basic authentication.
+
+```python
+from pymqrest import MQRESTSession, BasicAuth, LTPAAuth, CertificateAuth
+
+# Positional shorthand (Basic auth)
+session = MQRESTSession("https://...", "QM1", "user", "pass")
+
+# Explicit Basic auth
+session = MQRESTSession("https://...", "QM1", credentials=BasicAuth("user", "pass"))
+
+# LTPA token auth (login at construction)
+session = MQRESTSession("https://...", "QM1", credentials=LTPAAuth("user", "pass"))
+
+# mTLS client certificate auth
+session = MQRESTSession("https://...", "QM1", credentials=CertificateAuth("/cert.pem", "/key.pem"))
+```
+
+## Credential Types
+
+```{eval-rst}
+.. autoclass:: pymqrest.auth.BasicAuth
+   :exclude-members: username, password
+```
+
+```{eval-rst}
+.. autoclass:: pymqrest.auth.LTPAAuth
+   :exclude-members: username, password
+```
+
+```{eval-rst}
+.. autoclass:: pymqrest.auth.CertificateAuth
+   :exclude-members: cert_path, key_path
+```
+
+## Type Alias
+
+```{eval-rst}
+.. autodata:: pymqrest.auth.Credentials
+```
+
+## LTPA Login
+
+```{eval-rst}
+.. autofunction:: pymqrest.auth.perform_ltpa_login
+```

--- a/docs/sphinx/api/exceptions.md
+++ b/docs/sphinx/api/exceptions.md
@@ -5,6 +5,7 @@ All exceptions inherit from `MQRESTError`.
 ```
 Exception
 └── MQRESTError
+    ├── MQRESTAuthError        — authentication failures
     ├── MQRESTTransportError   — network/connection failures
     ├── MQRESTResponseError    — malformed responses
     └── MQRESTCommandError     — MQSC command failures
@@ -12,6 +13,12 @@ Exception
 
 ```{eval-rst}
 .. autoclass:: pymqrest.exceptions.MQRESTError
+   :show-inheritance:
+```
+
+```{eval-rst}
+.. autoclass:: pymqrest.exceptions.MQRESTAuthError
+   :members:
    :show-inheritance:
 ```
 

--- a/docs/sphinx/api/index.md
+++ b/docs/sphinx/api/index.md
@@ -4,6 +4,7 @@
 :maxdepth: 2
 
 session
+auth
 commands
 ensure
 mapping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ docstring-quotes = "double"
 "tests/**/*.py" = [
     "D1",   # Tests do not require docstrings.
     "S101", # Pytest assert style is expected.
+    "S105", # Hardcoded test passwords are expected in test fixtures.
+    "S106", # Hardcoded test password arguments are expected in test fixtures.
 ]
 "scripts/**/*.py" = [
     "D1",  # Internal tooling scripts do not require docstrings.

--- a/src/pymqrest/__init__.py
+++ b/src/pymqrest/__init__.py
@@ -2,8 +2,10 @@
 
 from importlib.metadata import version
 
+from .auth import BasicAuth, CertificateAuth, Credentials, LTPAAuth
 from .ensure import EnsureResult
 from .exceptions import (
+    MQRESTAuthError,
     MQRESTCommandError,
     MQRESTError,
     MQRESTResponseError,
@@ -21,7 +23,12 @@ from .session import MQRESTSession
 __version__ = version("pymqrest")
 
 __all__ = [
+    "BasicAuth",
+    "CertificateAuth",
+    "Credentials",
     "EnsureResult",
+    "LTPAAuth",
+    "MQRESTAuthError",
     "MQRESTCommandError",
     "MQRESTError",
     "MQRESTResponseError",

--- a/src/pymqrest/auth.py
+++ b/src/pymqrest/auth.py
@@ -1,0 +1,153 @@
+"""Authentication credential types and LTPA login support."""
+
+from __future__ import annotations
+
+import http.cookies
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .exceptions import MQRESTAuthError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .session import MQRESTTransport
+
+LTPA_COOKIE_NAME = "LtpaToken2"
+LTPA_LOGIN_PATH = "/login"
+ERROR_LTPA_LOGIN_FAILED = "LTPA login failed."
+ERROR_LTPA_TOKEN_MISSING = "LTPA login succeeded but no LtpaToken2 cookie was returned."  # noqa: S105
+
+
+@dataclass(frozen=True)
+class BasicAuth:
+    """HTTP Basic authentication credentials.
+
+    Attributes:
+        username: Username for HTTP Basic authentication.
+        password: Password for HTTP Basic authentication.
+
+    """
+
+    username: str
+    password: str
+
+
+@dataclass(frozen=True)
+class LTPAAuth:
+    """LTPA token-based authentication credentials.
+
+    The session performs an LTPA login at construction time and uses
+    the returned ``LtpaToken2`` cookie for subsequent requests.
+
+    Attributes:
+        username: Username for the LTPA login request.
+        password: Password for the LTPA login request.
+
+    """
+
+    username: str
+    password: str
+
+
+@dataclass(frozen=True)
+class CertificateAuth:
+    """Mutual TLS (mTLS) client certificate authentication.
+
+    The client certificate is configured on the transport layer.
+    No ``Authorization`` header is sent.
+
+    Attributes:
+        cert_path: Path to the client certificate PEM file.
+        key_path: Path to the private key PEM file, or ``None``
+            if the key is included in the certificate file.
+
+    """
+
+    cert_path: str
+    key_path: str | None = None
+
+
+Credentials = BasicAuth | LTPAAuth | CertificateAuth
+"""Type alias for the supported credential types."""
+
+
+def perform_ltpa_login(  # noqa: PLR0913
+    transport: MQRESTTransport,
+    rest_base_url: str,
+    credentials: LTPAAuth,
+    *,
+    csrf_token: str | None,
+    timeout_seconds: float | None,
+    verify_tls: bool,
+) -> str:
+    """Perform an LTPA login and return the ``LtpaToken2`` token value.
+
+    Args:
+        transport: The transport to use for the login POST request.
+        rest_base_url: Base URL of the MQ REST API.
+        credentials: LTPA credentials containing username and password.
+        csrf_token: CSRF token value for the request header.
+        timeout_seconds: Request timeout in seconds.
+        verify_tls: Whether to verify the server's TLS certificate.
+
+    Returns:
+        The ``LtpaToken2`` cookie value string.
+
+    Raises:
+        MQRESTAuthError: If the login request fails or the response
+            does not contain an ``LtpaToken2`` cookie.
+
+    """
+    login_url = f"{rest_base_url}{LTPA_LOGIN_PATH}"
+    headers: dict[str, str] = {"Accept": "application/json"}
+    if csrf_token is not None:
+        headers["ibm-mq-rest-csrf-token"] = csrf_token
+    payload: dict[str, object] = {
+        "username": credentials.username,
+        "password": credentials.password,
+    }
+    response = transport.post_json(
+        login_url,
+        payload,
+        headers=headers,
+        timeout_seconds=timeout_seconds,
+        verify_tls=verify_tls,
+    )
+    if response.status_code >= 400:  # noqa: PLR2004
+        raise MQRESTAuthError(
+            ERROR_LTPA_LOGIN_FAILED,
+            url=login_url,
+            status_code=response.status_code,
+        )
+    token = _extract_ltpa_token(response.headers)
+    if token is None:
+        raise MQRESTAuthError(
+            ERROR_LTPA_TOKEN_MISSING,
+            url=login_url,
+            status_code=response.status_code,
+        )
+    return token
+
+
+def _extract_ltpa_token(headers: Mapping[str, str]) -> str | None:
+    """Extract the ``LtpaToken2`` value from response ``Set-Cookie`` headers.
+
+    Uses :class:`http.cookies.SimpleCookie` for robust cookie parsing.
+
+    Args:
+        headers: Response headers mapping.
+
+    Returns:
+        The token string, or ``None`` if not found.
+
+    """
+    set_cookie = headers.get("Set-Cookie") or headers.get("set-cookie")
+    if not set_cookie:
+        return None
+    cookie = http.cookies.SimpleCookie()
+    cookie.load(set_cookie)
+    morsel = cookie.get(LTPA_COOKIE_NAME)
+    if morsel is not None:
+        return morsel.value
+    return None

--- a/src/pymqrest/exceptions.py
+++ b/src/pymqrest/exceptions.py
@@ -64,6 +64,32 @@ class MQRESTResponseError(MQRESTError):
         self.response_text = response_text
 
 
+class MQRESTAuthError(MQRESTError):
+    """Raised when authentication with the MQ REST API fails.
+
+    This indicates the server rejected credentials or a required
+    authentication token could not be obtained.
+
+    Attributes:
+        url: The endpoint URL where authentication failed.
+        status_code: The HTTP status code, or ``None`` if unavailable.
+
+    """
+
+    def __init__(self, message: str, *, url: str, status_code: int | None = None) -> None:
+        """Initialize with the failing endpoint URL and optional status code.
+
+        Args:
+            message: Human-readable error description.
+            url: The MQ REST endpoint URL where authentication failed.
+            status_code: The HTTP status code from the response.
+
+        """
+        super().__init__(message)
+        self.url = url
+        self.status_code = status_code
+
+
 class MQRESTCommandError(MQRESTError):
     """Raised when the MQ REST response indicates MQSC command failure.
 

--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from pymqrest.auth import LTPAAuth
 from pymqrest.ensure import EnsureResult
 from pymqrest.exceptions import MQRESTError
 from pymqrest.session import MQRESTSession
@@ -492,6 +493,22 @@ def test_ensure_channel_lifecycle() -> None:
 
     # Cleanup.
     session.delete_channel(name=TEST_ENSURE_CHANNEL)
+
+
+def test_ltpa_auth_display_qmgr() -> None:
+    config = load_integration_config()
+    session = MQRESTSession(
+        rest_base_url=config.rest_base_url,
+        qmgr_name=config.qmgr_name,
+        credentials=LTPAAuth(config.admin_user, config.admin_password),
+        verify_tls=config.verify_tls,
+    )
+
+    result = session.display_qmgr()
+
+    assert result is not None
+    assert isinstance(result, dict)
+    assert _contains_string_value(result, config.qmgr_name)
 
 
 def _require_integration_enabled() -> None:

--- a/tests/pymqrest/test_auth.py
+++ b/tests/pymqrest/test_auth.py
@@ -1,0 +1,241 @@
+"""Tests for authentication credential types and LTPA login."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pymqrest.auth import (
+    BasicAuth,
+    CertificateAuth,
+    LTPAAuth,
+    _extract_ltpa_token,
+    perform_ltpa_login,
+)
+from pymqrest.exceptions import MQRESTAuthError
+from pymqrest.session import TransportResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+TEST_PASSWORD = "secret"
+STATUS_OK = 200
+STATUS_UNAUTHORIZED = 401
+
+
+class FakeLoginTransport:
+    def __init__(self, response: TransportResponse) -> None:
+        self.response = response
+        self.recorded_url: str | None = None
+        self.recorded_payload: dict[str, object] | None = None
+        self.recorded_headers: dict[str, str] | None = None
+
+    def post_json(
+        self,
+        url: str,
+        payload: Mapping[str, object],
+        *,
+        headers: Mapping[str, str],
+        timeout_seconds: float | None,
+        verify_tls: bool,
+    ) -> TransportResponse:
+        _ = timeout_seconds
+        _ = verify_tls
+        self.recorded_url = url
+        self.recorded_payload = dict(payload)
+        self.recorded_headers = dict(headers)
+        return self.response
+
+
+# -- Credential dataclass construction and immutability --
+
+
+def test_basic_auth_construction() -> None:
+    cred = BasicAuth(username="user", password=TEST_PASSWORD)
+    assert cred.username == "user"
+    assert cred.password == TEST_PASSWORD
+
+
+def test_basic_auth_is_frozen() -> None:
+    cred = BasicAuth("user", TEST_PASSWORD)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cred.username = "other"  # type: ignore[misc]
+
+
+def test_ltpa_auth_construction() -> None:
+    cred = LTPAAuth(username="user", password=TEST_PASSWORD)
+    assert cred.username == "user"
+    assert cred.password == TEST_PASSWORD
+
+
+def test_ltpa_auth_is_frozen() -> None:
+    cred = LTPAAuth("user", TEST_PASSWORD)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cred.username = "other"  # type: ignore[misc]
+
+
+def test_certificate_auth_construction() -> None:
+    cred = CertificateAuth(cert_path="/cert.pem", key_path="/key.pem")
+    assert cred.cert_path == "/cert.pem"
+    assert cred.key_path == "/key.pem"
+
+
+def test_certificate_auth_key_path_optional() -> None:
+    cred = CertificateAuth(cert_path="/combined.pem")
+    assert cred.cert_path == "/combined.pem"
+    assert cred.key_path is None
+
+
+def test_certificate_auth_is_frozen() -> None:
+    cred = CertificateAuth("/cert.pem", "/key.pem")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cred.cert_path = "/other.pem"  # type: ignore[misc]
+
+
+# -- perform_ltpa_login success --
+
+
+def test_perform_ltpa_login_success() -> None:
+    transport = FakeLoginTransport(
+        TransportResponse(
+            status_code=STATUS_OK,
+            text="",
+            headers={"Set-Cookie": "LtpaToken2=abc123; Path=/; HttpOnly"},
+        ),
+    )
+
+    token = perform_ltpa_login(
+        transport,
+        "https://example.invalid/ibmmq/rest/v2",
+        LTPAAuth("user", TEST_PASSWORD),
+        csrf_token="local",
+        timeout_seconds=30.0,
+        verify_tls=False,
+    )
+
+    assert token == "abc123"
+    assert transport.recorded_url == "https://example.invalid/ibmmq/rest/v2/login"
+    assert transport.recorded_payload == {"username": "user", "password": TEST_PASSWORD}
+    assert transport.recorded_headers is not None
+    assert transport.recorded_headers["ibm-mq-rest-csrf-token"] == "local"
+
+
+def test_perform_ltpa_login_without_csrf_token() -> None:
+    transport = FakeLoginTransport(
+        TransportResponse(
+            status_code=STATUS_OK,
+            text="",
+            headers={"Set-Cookie": "LtpaToken2=token_value; Path=/"},
+        ),
+    )
+
+    token = perform_ltpa_login(
+        transport,
+        "https://example.invalid/ibmmq/rest/v2",
+        LTPAAuth("user", TEST_PASSWORD),
+        csrf_token=None,
+        timeout_seconds=30.0,
+        verify_tls=False,
+    )
+
+    assert token == "token_value"
+    assert transport.recorded_headers is not None
+    assert "ibm-mq-rest-csrf-token" not in transport.recorded_headers
+
+
+# -- perform_ltpa_login failures --
+
+
+def test_perform_ltpa_login_http_error_raises() -> None:
+    transport = FakeLoginTransport(
+        TransportResponse(
+            status_code=STATUS_UNAUTHORIZED,
+            text='{"error": "bad credentials"}',
+            headers={},
+        ),
+    )
+
+    with pytest.raises(MQRESTAuthError) as excinfo:
+        perform_ltpa_login(
+            transport,
+            "https://example.invalid/ibmmq/rest/v2",
+            LTPAAuth("user", TEST_PASSWORD),
+            csrf_token="local",
+            timeout_seconds=30.0,
+            verify_tls=False,
+        )
+
+    assert excinfo.value.url == "https://example.invalid/ibmmq/rest/v2/login"
+    assert excinfo.value.status_code == STATUS_UNAUTHORIZED
+
+
+def test_perform_ltpa_login_missing_token_raises() -> None:
+    transport = FakeLoginTransport(
+        TransportResponse(
+            status_code=STATUS_OK,
+            text="",
+            headers={"Set-Cookie": "SomeOtherCookie=value; Path=/"},
+        ),
+    )
+
+    with pytest.raises(MQRESTAuthError) as excinfo:
+        perform_ltpa_login(
+            transport,
+            "https://example.invalid/ibmmq/rest/v2",
+            LTPAAuth("user", TEST_PASSWORD),
+            csrf_token="local",
+            timeout_seconds=30.0,
+            verify_tls=False,
+        )
+
+    assert excinfo.value.url == "https://example.invalid/ibmmq/rest/v2/login"
+    assert excinfo.value.status_code == STATUS_OK
+
+
+def test_perform_ltpa_login_no_set_cookie_raises() -> None:
+    transport = FakeLoginTransport(
+        TransportResponse(
+            status_code=STATUS_OK,
+            text="",
+            headers={},
+        ),
+    )
+
+    with pytest.raises(MQRESTAuthError):
+        perform_ltpa_login(
+            transport,
+            "https://example.invalid/ibmmq/rest/v2",
+            LTPAAuth("user", TEST_PASSWORD),
+            csrf_token="local",
+            timeout_seconds=30.0,
+            verify_tls=False,
+        )
+
+
+# -- _extract_ltpa_token edge cases --
+
+
+def test_extract_ltpa_token_with_multiple_cookies() -> None:
+    headers = {"Set-Cookie": "Other=x; Path=/, LtpaToken2=multi_tok; Path=/; Secure"}
+    assert _extract_ltpa_token(headers) == "multi_tok"
+
+
+def test_extract_ltpa_token_no_match() -> None:
+    headers = {"Set-Cookie": "SessionId=abc; Path=/"}
+    assert _extract_ltpa_token(headers) is None
+
+
+def test_extract_ltpa_token_empty_set_cookie() -> None:
+    headers = {"Set-Cookie": ""}
+    assert _extract_ltpa_token(headers) is None
+
+
+def test_extract_ltpa_token_no_headers() -> None:
+    assert _extract_ltpa_token({}) is None
+
+
+def test_extract_ltpa_token_lowercase_header() -> None:
+    headers = {"set-cookie": "LtpaToken2=lower_tok; Path=/"}
+    assert _extract_ltpa_token(headers) == "lower_tok"

--- a/tests/pymqrest/test_ensure.py
+++ b/tests/pymqrest/test_ensure.py
@@ -14,7 +14,7 @@ from pymqrest.session import MQRESTSession, TransportResponse
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
-TEST_PASSWORD = "pass"  # noqa: S105
+TEST_PASSWORD = "pass"
 EXPECT_ONE_REQUEST = 1
 EXPECT_TWO_REQUESTS = 2
 


### PR DESCRIPTION
## Summary

- Add `BasicAuth`, `LTPAAuth`, and `CertificateAuth` credential dataclasses in new `auth.py` module
- Extend `MQRESTSession.__init__` with `credentials` keyword parameter (positional `username`/`password` remains backward compatible)
- Add `MQRESTAuthError` exception for authentication failures
- Add `client_cert` parameter to `RequestsTransport` for mTLS support
- Add Sphinx API documentation for the authentication module and updated exception hierarchy

Fixes #130

## Test plan

- [x] Credential dataclass construction and immutability (test_auth.py)
- [x] `perform_ltpa_login` success, HTTP error, and missing token cases (test_auth.py)
- [x] LTPA token extraction edge cases — multiple cookies, no match, empty, lowercase header (test_auth.py)
- [x] Backward compatibility — positional `username`/`password` still works (test_session.py)
- [x] `BasicAuth` credential equivalent to positional form (test_session.py)
- [x] `LTPAAuth` — login at construction + cookie header on commands (test_session.py)
- [x] `CertificateAuth` — no auth header, CSRF present, transport cert configured (test_session.py)
- [x] Mutual exclusivity and missing-credential `TypeError` cases (test_session.py)
- [x] `RequestsTransport` mTLS cert configuration (test_session.py)
- [x] LTPA integration test against real container (test_mq_integration.py)
- [x] 178 tests pass, 100% branch coverage, full validation suite green
- [x] Sphinx build succeeds with `-W` (warnings-as-errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)