### PR TITLE
refactor: use snake_case attribute names exclusively in examples

### DIFF
--- a/examples/channel_status.py
+++ b/examples/channel_status.py
@@ -41,7 +41,7 @@ def report_channel_status(session: MQRESTSession) -> list[ChannelInfo]:
 
     definitions: dict[str, dict[str, object]] = {}
     for channel in channels:
-        cname = str(channel.get("channel_name") or channel.get("CHANNEL", "")).strip()
+        cname = str(channel.get("channel_name", "")).strip()
         if cname:
             definitions[cname] = channel
 
@@ -49,8 +49,8 @@ def report_channel_status(session: MQRESTSession) -> list[ChannelInfo]:
     try:
         statuses = session.display_chstatus(name="*")
         for entry in statuses:
-            cname = str(entry.get("channel_name") or entry.get("CHANNEL", "")).strip()
-            cstatus = str(entry.get("status") or entry.get("STATUS", "")).strip()
+            cname = str(entry.get("channel_name", "")).strip()
+            cstatus = str(entry.get("status", "")).strip()
             if cname:
                 live_status[cname] = cstatus
     except MQRESTError:
@@ -58,8 +58,8 @@ def report_channel_status(session: MQRESTSession) -> list[ChannelInfo]:
 
     results: list[ChannelInfo] = []
     for cname, defn in sorted(definitions.items()):
-        ctype = str(defn.get("channel_type") or defn.get("CHLTYPE", "")).strip()
-        conname = str(defn.get("connection_name") or defn.get("CONNAME", "")).strip()
+        ctype = str(defn.get("channel_type", "")).strip()
+        conname = str(defn.get("connection_name", "")).strip()
         status = live_status.get(cname, "INACTIVE")
 
         results.append(

--- a/examples/dlq_inspector.py
+++ b/examples/dlq_inspector.py
@@ -48,7 +48,7 @@ def inspect_dlq(session: MQRESTSession) -> DLQReport:
 
     dlq_name = ""
     if qmgr:
-        dlq_name = str(qmgr.get("dead_letter_q_name") or qmgr.get("DEADQ", "")).strip()
+        dlq_name = str(qmgr.get("dead_letter_q_name", "")).strip()
 
     if not dlq_name:
         return DLQReport(
@@ -78,10 +78,10 @@ def inspect_dlq(session: MQRESTSession) -> DLQReport:
         )
 
     dlq = queues[0]
-    current_depth = _to_int(dlq.get("current_queue_depth") or dlq.get("CURDEPTH", 0))
-    max_depth = _to_int(dlq.get("max_queue_depth") or dlq.get("MAXDEPTH", 0))
-    open_input = _to_int(dlq.get("open_input_count") or dlq.get("IPPROCS", 0))
-    open_output = _to_int(dlq.get("open_output_count") or dlq.get("OPPROCS", 0))
+    current_depth = _to_int(dlq.get("current_queue_depth", 0))
+    max_depth = _to_int(dlq.get("max_queue_depth", 0))
+    open_input = _to_int(dlq.get("open_input_count", 0))
+    open_output = _to_int(dlq.get("open_output_count", 0))
     depth_pct = (current_depth / max_depth * 100.0) if max_depth > 0 else 0.0
 
     if current_depth == 0:

--- a/examples/health_check.py
+++ b/examples/health_check.py
@@ -59,18 +59,18 @@ def check_health(session: MQRESTSession) -> QMHealthResult:
     result.reachable = True
 
     if qmgr:
-        name = qmgr.get("queue_manager_name") or qmgr.get("QMNAME", "")
+        name = qmgr.get("queue_manager_name", "")
         if isinstance(name, str) and name.strip():
             result.qmgr_name = name.strip()
 
     qmstatus = session.display_qmstatus()
     if qmstatus:
-        status = qmstatus.get("status") or qmstatus.get("STATUS", "UNKNOWN")
+        status = qmstatus.get("status", "UNKNOWN")
         result.status = str(status).strip()
 
     cmdserv = session.display_cmdserv()
     if cmdserv:
-        status = cmdserv.get("status") or cmdserv.get("STATUS", "UNKNOWN")
+        status = cmdserv.get("status", "UNKNOWN")
         result.command_server = str(status).strip()
 
     try:
@@ -79,8 +79,8 @@ def check_health(session: MQRESTSession) -> QMHealthResult:
         listeners = []
 
     for listener in listeners:
-        lname = listener.get("listener_name") or listener.get("LISTENER", "")
-        lstatus = listener.get("control") or listener.get("CONTROL", "")
+        lname = listener.get("listener_name", "")
+        lstatus = listener.get("control", "")
         result.listeners.append(ListenerResult(name=str(lname).strip(), status=str(lstatus).strip()))
 
     result.passed = result.reachable and result.status != "UNKNOWN"

--- a/examples/queue_depth_monitor.py
+++ b/examples/queue_depth_monitor.py
@@ -51,16 +51,16 @@ def monitor_queue_depths(
     results: list[QueueDepthInfo] = []
 
     for queue in queues:
-        qname = queue.get("queue_name") or queue.get("QUEUE", "")
-        qtype = queue.get("type") or queue.get("TYPE", "")
+        qname = queue.get("queue_name", "")
+        qtype = queue.get("type", "")
 
         if str(qtype).strip().upper() not in ("QLOCAL", "LOCAL"):
             continue
 
-        current_depth = _to_int(queue.get("current_queue_depth") or queue.get("CURDEPTH", 0))
-        max_depth = _to_int(queue.get("max_queue_depth") or queue.get("MAXDEPTH", 0))
-        open_input = _to_int(queue.get("open_input_count") or queue.get("IPPROCS", 0))
-        open_output = _to_int(queue.get("open_output_count") or queue.get("OPPROCS", 0))
+        current_depth = _to_int(queue.get("current_queue_depth", 0))
+        max_depth = _to_int(queue.get("max_queue_depth", 0))
+        open_input = _to_int(queue.get("open_input_count", 0))
+        open_output = _to_int(queue.get("open_output_count", 0))
 
         depth_pct = (current_depth / max_depth * 100.0) if max_depth > 0 else 0.0
 


### PR DESCRIPTION
## Summary

- Remove MQSC fallback patterns from all four examples that used them
- Replace `obj.get("snake_case") or obj.get("MQSC", default)` with `obj.get("snake_case", default)`
- Examples now demonstrate the mapped API exclusively, avoiding encouraging direct use of unmapped MQSC attribute names

**Files changed**: `health_check.py`, `channel_status.py`, `dlq_inspector.py`, `queue_depth_monitor.py`
**No change needed**: `provision_environment.py` (already snake_case only)

## Test plan

- [x] `uv run python3 scripts/dev/validate_local.py` passes all gates
- [x] No behavioural change when mapping is enabled (the default)

Ref #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)