### PR TITLE
refactor: require credentials keyword argument, drop username/password

### DIFF
--- a/docs/sphinx/api/auth.md
+++ b/docs/sphinx/api/auth.md
@@ -5,16 +5,12 @@ authentication modes supported by the IBM MQ REST API: HTTP Basic,
 LTPA token, and mutual TLS (mTLS) client certificates.
 
 Pass a credential object to `MQRESTSession` via the `credentials`
-keyword argument, or use the positional `username`/`password`
-shorthand for Basic authentication.
+keyword argument.
 
 ```python
 from pymqrest import MQRESTSession, BasicAuth, LTPAAuth, CertificateAuth
 
-# Positional shorthand (Basic auth)
-session = MQRESTSession("https://...", "QM1", "user", "pass")
-
-# Explicit Basic auth
+# Basic auth
 session = MQRESTSession("https://...", "QM1", credentials=BasicAuth("user", "pass"))
 
 # LTPA token auth (login at construction)

--- a/docs/sphinx/ensure-methods.md
+++ b/docs/sphinx/ensure-methods.md
@@ -33,12 +33,12 @@ class EnsureResult(enum.Enum):
 
 ```python
 from pymqrest import MQRESTSession, EnsureResult
+from pymqrest.auth import BasicAuth
 
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    username="mqadmin",
-    password="mqadmin",
+    credentials=BasicAuth("mqadmin", "mqadmin"),
     verify_tls=False,
 )
 

--- a/docs/sphinx/examples.md
+++ b/docs/sphinx/examples.md
@@ -103,13 +103,13 @@ to call the functions directly:
 
 ```python
 from pymqrest import MQRESTSession
+from pymqrest.auth import BasicAuth
 from examples.health_check import check_health
 
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    username="mqadmin",
-    password="mqadmin",
+    credentials=BasicAuth("mqadmin", "mqadmin"),
     verify_tls=False,
 )
 

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -21,12 +21,12 @@ REST API base URL, queue manager name, and credentials:
 
 ```python
 from pymqrest import MQRESTSession
+from pymqrest.auth import BasicAuth
 
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    username="mqadmin",
-    password="mqadmin",
+    credentials=BasicAuth("mqadmin", "mqadmin"),
     verify_tls=False,  # for local development only
 )
 ```
@@ -80,8 +80,7 @@ Mapping can be disabled at the session level or per method call:
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    username="mqadmin",
-    password="mqadmin",
+    credentials=BasicAuth("mqadmin", "mqadmin"),
     map_attributes=False,
 )
 ```
@@ -99,8 +98,7 @@ unchanged:
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    username="mqadmin",
-    password="mqadmin",
+    credentials=BasicAuth("mqadmin", "mqadmin"),
     mapping_strict=False,
 )
 ```

--- a/examples/channel_status.py
+++ b/examples/channel_status.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from os import getenv
 
 from pymqrest import MQRESTError, MQRESTSession
+from pymqrest.auth import BasicAuth
 
 
 @dataclass
@@ -119,8 +120,7 @@ if __name__ == "__main__":
     session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-        username=getenv("MQ_ADMIN_USER", "mqadmin"),
-        password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 

--- a/examples/dlq_inspector.py
+++ b/examples/dlq_inspector.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from os import getenv
 
 from pymqrest import MQRESTSession
+from pymqrest.auth import BasicAuth
 
 CRITICAL_DEPTH_PCT = 90
 
@@ -146,8 +147,7 @@ if __name__ == "__main__":
     session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-        username=getenv("MQ_ADMIN_USER", "mqadmin"),
-        password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 

--- a/examples/health_check.py
+++ b/examples/health_check.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from os import getenv
 
 from pymqrest import MQRESTError, MQRESTSession
+from pymqrest.auth import BasicAuth
 
 
 @dataclass
@@ -121,8 +122,7 @@ if __name__ == "__main__":
         MQRESTSession(
             rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
             qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-            username=getenv("MQ_ADMIN_USER", "mqadmin"),
-            password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+            credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
             verify_tls=False,
         )
     )
@@ -133,8 +133,7 @@ if __name__ == "__main__":
             MQRESTSession(
                 rest_base_url=qm2_url,
                 qmgr_name="QM2",
-                username=getenv("MQ_ADMIN_USER", "mqadmin"),
-                password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+                credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
                 verify_tls=False,
             )
         )

--- a/examples/provision_environment.py
+++ b/examples/provision_environment.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from os import getenv
 
 from pymqrest import MQRESTError, MQRESTSession
+from pymqrest.auth import BasicAuth
 
 PREFIX = "PROV"
 
@@ -288,16 +289,14 @@ if __name__ == "__main__":
     qm1_session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name="QM1",
-        username=getenv("MQ_ADMIN_USER", "mqadmin"),
-        password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 
     qm2_session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL_QM2", "https://localhost:9444/ibmmq/rest/v2"),
         qmgr_name="QM2",
-        username=getenv("MQ_ADMIN_USER", "mqadmin"),
-        password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 

--- a/examples/queue_depth_monitor.py
+++ b/examples/queue_depth_monitor.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from os import getenv
 
 from pymqrest import MQRESTSession
+from pymqrest.auth import BasicAuth
 
 
 @dataclass
@@ -125,8 +126,7 @@ if __name__ == "__main__":
     session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-        username=getenv("MQ_ADMIN_USER", "mqadmin"),
-        password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -11,6 +11,7 @@ from examples.health_check import check_health
 from examples.provision_environment import provision, teardown
 from examples.queue_depth_monitor import monitor_queue_depths
 
+from pymqrest.auth import BasicAuth
 from pymqrest.session import MQRESTSession
 
 INTEGRATION_ENV_FLAG = "PYMQREST_RUN_INTEGRATION"
@@ -27,8 +28,7 @@ def _qm1_session() -> MQRESTSession:
     return MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-        username=getenv("MQ_ADMIN_USER", "mqadmin"),
-        password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 
@@ -37,8 +37,7 @@ def _qm2_session() -> MQRESTSession:
     return MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL_QM2", "https://localhost:9444/ibmmq/rest/v2"),
         qmgr_name="QM2",
-        username=getenv("MQ_ADMIN_USER", "mqadmin"),
-        password=getenv("MQ_ADMIN_PASSWORD", "mqadmin"),
+        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 

--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from pymqrest.auth import LTPAAuth
+from pymqrest.auth import BasicAuth, LTPAAuth
 from pymqrest.ensure import EnsureResult
 from pymqrest.exceptions import MQRESTError
 from pymqrest.session import MQRESTSession
@@ -525,8 +525,7 @@ def _build_session(
     return MQRESTSession(
         rest_base_url=config.rest_base_url,
         qmgr_name=config.qmgr_name,
-        username=config.admin_user,
-        password=config.admin_password,
+        credentials=BasicAuth(config.admin_user, config.admin_password),
         verify_tls=config.verify_tls,
         map_attributes=map_attributes,
         mapping_strict=mapping_strict,

--- a/tests/pymqrest/test_ensure.py
+++ b/tests/pymqrest/test_ensure.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from pymqrest.auth import BasicAuth
 from pymqrest.ensure import EnsureResult, _values_match
 from pymqrest.session import MQRESTSession, TransportResponse
 
@@ -89,8 +90,7 @@ def _build_session(
     kwargs: dict[str, object] = {
         "rest_base_url": "https://example.invalid/ibmmq/rest/v2",
         "qmgr_name": "QM1",
-        "username": "user",
-        "password": TEST_PASSWORD,
+        "credentials": BasicAuth("user", TEST_PASSWORD),
         "transport": transport,
     }
     if mapping_strict is not None:

--- a/tests/pymqrest/test_session.py
+++ b/tests/pymqrest/test_session.py
@@ -78,8 +78,7 @@ def _build_session(
     kwargs: dict[str, object] = {
         "rest_base_url": "https://example.invalid/ibmmq/rest/v2",
         "qmgr_name": "QM1",
-        "username": "user",
-        "password": TEST_PASSWORD,
+        "credentials": BasicAuth("user", TEST_PASSWORD),
         "transport": transport,
     }
     if mapping_strict is not None:
@@ -252,8 +251,7 @@ def test_map_response_parameters_unknown_key_strict() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         mapping_strict=True,
     )
 
@@ -269,8 +267,7 @@ def test_map_response_parameters_unknown_qualifier_strict() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         mapping_strict=True,
     )
 
@@ -356,8 +353,7 @@ def test_build_headers_excludes_csrf_token_when_none() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         csrf_token=None,
     )
 
@@ -477,8 +473,7 @@ def test_map_attributes_false_returns_raw_parameters() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=transport,
         map_attributes=False,
     )
@@ -492,8 +487,7 @@ def test_resolve_mapping_qualifier_fallbacks() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
     )
 
     assert session._resolve_mapping_qualifier("DISPLAY", "QMGR") == "qmgr"  # noqa: SLF001
@@ -632,8 +626,7 @@ def test_resolve_mapping_qualifier_handles_invalid_command_entry(
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
     )
 
     assert session._resolve_mapping_qualifier("BOGUS", "THING") == "thing"  # noqa: SLF001
@@ -746,8 +739,7 @@ def test_display_queue_where_passthrough_when_mapping_disabled() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=transport,
         map_attributes=False,
     )
@@ -848,8 +840,7 @@ def test_display_queue_where_overrides_request_parameters_where() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=transport,
         map_attributes=False,
     )
@@ -967,8 +958,7 @@ def test_nested_objects_flattened_without_mapping() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=FakeTransport(
             TransportResponse(
                 status_code=200,
@@ -1003,8 +993,7 @@ def test_nested_objects_empty_list_returns_empty() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=FakeTransport(
             TransportResponse(
                 status_code=200,
@@ -1049,8 +1038,7 @@ def test_nested_objects_mixed_with_flat_items() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=FakeTransport(
             TransportResponse(
                 status_code=200,
@@ -1086,8 +1074,7 @@ def test_nested_objects_single_entry() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=FakeTransport(
             TransportResponse(
                 status_code=200,
@@ -1121,8 +1108,7 @@ def test_nested_objects_non_list_passes_through() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=FakeTransport(
             TransportResponse(
                 status_code=200,
@@ -1160,8 +1146,7 @@ def test_nested_objects_non_dict_items_skipped() -> None:
     session = MQRESTSession(
         rest_base_url="https://example.invalid/ibmmq/rest/v2",
         qmgr_name="QM1",
-        username="user",
-        password=TEST_PASSWORD,
+        credentials=BasicAuth("user", TEST_PASSWORD),
         transport=FakeTransport(
             TransportResponse(
                 status_code=200,
@@ -1250,71 +1235,6 @@ class MultiResponseTransport:
 # -- Credential dispatch tests --
 
 
-def test_positional_username_password_backward_compatible() -> None:
-    response_payload = {
-        "commandResponse": [
-            {"completionCode": 0, "reasonCode": 0, "parameters": {"QMNAME": "QM1"}},
-        ],
-        "overallCompletionCode": 0,
-        "overallReasonCode": 0,
-    }
-    response_text = json.dumps(response_payload)
-    transport = FakeTransport(
-        TransportResponse(status_code=200, text=response_text, headers={}),
-    )
-
-    session = MQRESTSession(
-        "https://example.invalid/ibmmq/rest/v2",
-        "QM1",
-        "user",
-        TEST_PASSWORD,
-        transport=transport,
-    )
-
-    result = session.display_qmgr()
-    assert result == {"queue_manager_name": "QM1"}
-    recorded = transport.recorded_requests[0]
-    assert recorded.headers["Authorization"].startswith("Basic ")
-
-
-def test_credentials_basic_auth_equivalent_to_positional() -> None:
-    response_payload = {
-        "commandResponse": [],
-        "overallCompletionCode": 0,
-        "overallReasonCode": 0,
-    }
-    response_text = json.dumps(response_payload)
-
-    transport_positional = FakeTransport(
-        TransportResponse(status_code=200, text=response_text, headers={}),
-    )
-    session_positional = MQRESTSession(
-        "https://example.invalid/ibmmq/rest/v2",
-        "QM1",
-        "user",
-        TEST_PASSWORD,
-        transport=transport_positional,
-    )
-
-    transport_explicit = FakeTransport(
-        TransportResponse(status_code=200, text=response_text, headers={}),
-    )
-    session_explicit = MQRESTSession(
-        "https://example.invalid/ibmmq/rest/v2",
-        "QM1",
-        credentials=BasicAuth("user", TEST_PASSWORD),
-        transport=transport_explicit,
-    )
-
-    session_positional.display_queue()
-    session_explicit.display_queue()
-
-    assert (
-        transport_positional.recorded_requests[0].headers["Authorization"]
-        == transport_explicit.recorded_requests[0].headers["Authorization"]
-    )
-
-
 def test_credentials_ltpa_auth_sends_cookie_header() -> None:
     login_response = TransportResponse(
         status_code=200,
@@ -1386,40 +1306,11 @@ def test_credentials_certificate_auth_no_auth_header() -> None:
     assert recorded.headers["ibm-mq-rest-csrf-token"] == "local"
 
 
-def test_credentials_and_username_raises_type_error() -> None:
-    with pytest.raises(TypeError, match="Cannot specify both"):
-        MQRESTSession(
-            "https://example.invalid/ibmmq/rest/v2",
-            "QM1",
-            "user",
-            TEST_PASSWORD,
-            credentials=BasicAuth("other", TEST_PASSWORD),
-        )
-
-
 def test_no_credentials_raises_type_error() -> None:
-    with pytest.raises(TypeError, match="Must provide either"):
+    with pytest.raises(TypeError, match="credentials"):
         MQRESTSession(
             "https://example.invalid/ibmmq/rest/v2",
             "QM1",
-        )
-
-
-def test_username_without_password_raises_type_error() -> None:
-    with pytest.raises(TypeError, match="Both 'username' and 'password'"):
-        MQRESTSession(
-            "https://example.invalid/ibmmq/rest/v2",
-            "QM1",
-            "user",
-        )
-
-
-def test_password_without_username_raises_type_error() -> None:
-    with pytest.raises(TypeError, match="Both 'username' and 'password'"):
-        MQRESTSession(
-            "https://example.invalid/ibmmq/rest/v2",
-            "QM1",
-            password=TEST_PASSWORD,
         )
 
 


### PR DESCRIPTION
## Summary

- Remove `username` and `password` positional parameters from `MQRESTSession.__init__`, making `credentials` a required keyword-only argument
- Delete `_resolve_credentials()` helper and its three error constants (`ERROR_CREDENTIALS_CONFLICT`, `ERROR_CREDENTIALS_MISSING`, `ERROR_CREDENTIALS_INCOMPLETE`)
- Update all 14 affected files: session, tests, examples, and Sphinx docs

Ref #131

## Test plan

- [x] Full validation suite passes (`uv run python3 scripts/dev/validate_local.py`)
- [x] 173 tests pass, 100% coverage maintained
- [x] All linting (ruff check + format), type checking (mypy + ty), and doc linting pass
- [x] `test_no_credentials_raises_type_error` updated to match Python native missing-keyword error

Generated with [Claude Code](https://claude.com/claude-code)