### PR TITLE
docs: separate unmapped qualifiers in mapping index, rewrite auth docs

### DIFF
--- a/docs/sphinx/api/auth.md
+++ b/docs/sphinx/api/auth.md
@@ -1,8 +1,8 @@
 # Authentication
 
 The authentication module provides credential types for the three
-authentication modes supported by the IBM MQ REST API: HTTP Basic,
-LTPA token, and mutual TLS (mTLS) client certificates.
+authentication modes supported by the IBM MQ REST API: mutual TLS (mTLS)
+client certificates, LTPA token, and HTTP Basic.
 
 Pass a credential object to `MQRESTSession` via the `credentials`
 keyword argument.
@@ -10,21 +10,21 @@ keyword argument.
 ```python
 from pymqrest import MQRESTSession, BasicAuth, LTPAAuth, CertificateAuth
 
-# Basic auth
-session = MQRESTSession("https://...", "QM1", credentials=BasicAuth("user", "pass"))
+# mTLS client certificate auth — strongest; no shared secrets
+session = MQRESTSession("https://...", "QM1", credentials=CertificateAuth("/cert.pem", "/key.pem"))
 
-# LTPA token auth (login at construction)
+# LTPA token auth — credentials sent once at login, then cookie-based
 session = MQRESTSession("https://...", "QM1", credentials=LTPAAuth("user", "pass"))
 
-# mTLS client certificate auth
-session = MQRESTSession("https://...", "QM1", credentials=CertificateAuth("/cert.pem", "/key.pem"))
+# Basic auth — credentials sent with every request
+session = MQRESTSession("https://...", "QM1", credentials=BasicAuth("user", "pass"))
 ```
 
 ## Credential Types
 
 ```{eval-rst}
-.. autoclass:: pymqrest.auth.BasicAuth
-   :exclude-members: username, password
+.. autoclass:: pymqrest.auth.CertificateAuth
+   :exclude-members: cert_path, key_path
 ```
 
 ```{eval-rst}
@@ -33,9 +33,33 @@ session = MQRESTSession("https://...", "QM1", credentials=CertificateAuth("/cert
 ```
 
 ```{eval-rst}
-.. autoclass:: pymqrest.auth.CertificateAuth
-   :exclude-members: cert_path, key_path
+.. autoclass:: pymqrest.auth.BasicAuth
+   :exclude-members: username, password
 ```
+
+## Choosing between LTPA and Basic authentication
+
+Both LTPA and Basic authentication use a username and password. The key
+difference is how often those credentials cross the wire.
+
+**Prefer LTPA when possible.** Credentials are sent once during the
+`/login` request; subsequent API calls carry only the LTPA cookie. This
+reduces credential exposure and is more efficient for sessions that issue
+many commands.
+
+**Basic authentication is appropriate when:**
+
+- The mqweb configuration does not enable the `/login` endpoint (for
+  example, minimal container images that only expose the REST API).
+- A reverse proxy or API gateway handles authentication and forwards a
+  Basic auth header; cookie-based flows may not survive the proxy.
+- Single-command scripts where the login round-trip doubles the request
+  count for no security benefit.
+- Long-running sessions where LTPA token expiry (typically two hours)
+  could cause mid-operation failures; pymqrest does not currently
+  re-authenticate automatically.
+- Local development or CI against a `localhost` container, where
+  transport security is not a concern.
 
 ## Type Alias
 

--- a/docs/sphinx/mappings/index.md
+++ b/docs/sphinx/mappings/index.md
@@ -12,8 +12,6 @@ archive
 authinfo
 authrec
 authserv
-bsds
-buffpool
 cfstatus
 cfstruct
 channel
@@ -22,7 +20,6 @@ chlauth
 chstatus
 clusqmgr
 cluster
-cmdserv
 comminfo
 conn
 entauth
@@ -31,11 +28,9 @@ indoubt
 listener
 log
 lsstatus
-maxsmsgs
 namelist
 policy
 process
-psid
 pubsub
 qmgr
 queue
@@ -47,12 +42,26 @@ smdsconn
 stgclass
 sub
 svstatus
-tcluster
-thread
 topic
 topicstr
-tpipe
 tpstatus
-trace
 usage
+```
+
+## Qualifiers without attribute mappings
+
+The following qualifiers are supported by pymqrest but do not yet have attribute name translations: `bsds`, `buffpool`, `cmdserv`, `maxsmsgs`, `psid`, `tcluster`, `thread`, `tpipe`, `trace`.
+
+```{toctree}
+:hidden:
+
+bsds
+buffpool
+cmdserv
+maxsmsgs
+psid
+tcluster
+thread
+tpipe
+trace
 ```


### PR DESCRIPTION
## Summary

- Update the mapping index generator to partition qualifiers into mapped (39) and unmapped (9), producing a cleaner toctree that only links to pages with actual attribute translations
- Reorder authentication docs most-secure-first (CertificateAuth, LTPAAuth, BasicAuth) and add a "Choosing between LTPA and Basic authentication" section with practical trade-off guidance

Ref #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)