### PR TITLE
refactor: make perform_ltpa_login internal, remove from public docs

### DIFF
--- a/docs/sphinx/api/auth.md
+++ b/docs/sphinx/api/auth.md
@@ -66,9 +66,3 @@ many commands.
 ```{eval-rst}
 .. autodata:: pymqrest.auth.Credentials
 ```
-
-## LTPA Login
-
-```{eval-rst}
-.. autofunction:: pymqrest.auth.perform_ltpa_login
-```

--- a/src/pymqrest/auth.py
+++ b/src/pymqrest/auth.py
@@ -72,7 +72,7 @@ Credentials = BasicAuth | LTPAAuth | CertificateAuth
 """Type alias for the supported credential types."""
 
 
-def perform_ltpa_login(  # noqa: PLR0913
+def _perform_ltpa_login(  # noqa: PLR0913
     transport: MQRESTTransport,
     rest_base_url: str,
     credentials: LTPAAuth,

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -11,7 +11,7 @@ from typing import Protocol, cast
 import requests
 from requests import RequestException
 
-from .auth import LTPA_COOKIE_NAME, BasicAuth, CertificateAuth, Credentials, LTPAAuth, perform_ltpa_login
+from .auth import LTPA_COOKIE_NAME, BasicAuth, CertificateAuth, Credentials, LTPAAuth, _perform_ltpa_login
 from .commands import MQRESTCommandMixin
 from .ensure import MQRESTEnsureMixin
 from .exceptions import (
@@ -244,7 +244,7 @@ class MQRESTSession(MQRESTEnsureMixin, MQRESTCommandMixin):
 
         self._ltpa_token: str | None = None
         if isinstance(credentials, LTPAAuth):
-            self._ltpa_token = perform_ltpa_login(
+            self._ltpa_token = _perform_ltpa_login(
                 self._transport,
                 self._rest_base_url,
                 credentials,

--- a/tests/pymqrest/test_auth.py
+++ b/tests/pymqrest/test_auth.py
@@ -12,7 +12,7 @@ from pymqrest.auth import (
     CertificateAuth,
     LTPAAuth,
     _extract_ltpa_token,
-    perform_ltpa_login,
+    _perform_ltpa_login,
 )
 from pymqrest.exceptions import MQRESTAuthError
 from pymqrest.session import TransportResponse
@@ -94,7 +94,7 @@ def test_certificate_auth_is_frozen() -> None:
         cred.cert_path = "/other.pem"  # type: ignore[misc]
 
 
-# -- perform_ltpa_login success --
+# -- _perform_ltpa_login success --
 
 
 def test_perform_ltpa_login_success() -> None:
@@ -106,7 +106,7 @@ def test_perform_ltpa_login_success() -> None:
         ),
     )
 
-    token = perform_ltpa_login(
+    token = _perform_ltpa_login(
         transport,
         "https://example.invalid/ibmmq/rest/v2",
         LTPAAuth("user", TEST_PASSWORD),
@@ -131,7 +131,7 @@ def test_perform_ltpa_login_without_csrf_token() -> None:
         ),
     )
 
-    token = perform_ltpa_login(
+    token = _perform_ltpa_login(
         transport,
         "https://example.invalid/ibmmq/rest/v2",
         LTPAAuth("user", TEST_PASSWORD),
@@ -145,7 +145,7 @@ def test_perform_ltpa_login_without_csrf_token() -> None:
     assert "ibm-mq-rest-csrf-token" not in transport.recorded_headers
 
 
-# -- perform_ltpa_login failures --
+# -- _perform_ltpa_login failures --
 
 
 def test_perform_ltpa_login_http_error_raises() -> None:
@@ -158,7 +158,7 @@ def test_perform_ltpa_login_http_error_raises() -> None:
     )
 
     with pytest.raises(MQRESTAuthError) as excinfo:
-        perform_ltpa_login(
+        _perform_ltpa_login(
             transport,
             "https://example.invalid/ibmmq/rest/v2",
             LTPAAuth("user", TEST_PASSWORD),
@@ -181,7 +181,7 @@ def test_perform_ltpa_login_missing_token_raises() -> None:
     )
 
     with pytest.raises(MQRESTAuthError) as excinfo:
-        perform_ltpa_login(
+        _perform_ltpa_login(
             transport,
             "https://example.invalid/ibmmq/rest/v2",
             LTPAAuth("user", TEST_PASSWORD),
@@ -204,7 +204,7 @@ def test_perform_ltpa_login_no_set_cookie_raises() -> None:
     )
 
     with pytest.raises(MQRESTAuthError):
-        perform_ltpa_login(
+        _perform_ltpa_login(
             transport,
             "https://example.invalid/ibmmq/rest/v2",
             LTPAAuth("user", TEST_PASSWORD),


### PR DESCRIPTION
## Summary

- Rename `perform_ltpa_login` to `_perform_ltpa_login` — it is only called internally from `MQRESTSession` construction and takes internal types (`MQRESTTransport`, `csrf_token`) that end users never construct directly
- Remove the "LTPA Login" section from the authentication docs page since the function is no longer part of the public API

Ref #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)