### PR TITLE
docs: remove misleading "yet" from unmapped qualifier description

### DIFF
--- a/docs/sphinx/mappings/index.md
+++ b/docs/sphinx/mappings/index.md
@@ -50,7 +50,7 @@ usage
 
 ## Qualifiers without attribute mappings
 
-The following qualifiers are supported by pymqrest but do not yet have attribute name translations: `bsds`, `buffpool`, `cmdserv`, `maxsmsgs`, `psid`, `tcluster`, `thread`, `tpipe`, `trace`.
+The following qualifiers are supported by pymqrest but do not have attribute name translations: `bsds`, `buffpool`, `cmdserv`, `maxsmsgs`, `psid`, `tcluster`, `thread`, `tpipe`, `trace`.
 
 ```{toctree}
 :hidden:

--- a/scripts/dev/generate_mapping_docs.py
+++ b/scripts/dev/generate_mapping_docs.py
@@ -213,7 +213,7 @@ def generate_index_page(
         lines.append("")
         formatted = ", ".join(f"`{q}`" for q in sorted(unmapped))
         lines.append(
-            f"The following qualifiers are supported by pymqrest but do not yet"
+            f"The following qualifiers are supported by pymqrest but do not"
             f" have attribute name translations: {formatted}.",
         )
         lines.append("")


### PR DESCRIPTION
## Summary

- Remove the word "yet" from the unmapped qualifier prose in the mapping index — these qualifiers have no attributes to map, so the wording implied incomplete work rather than an intentional absence

Ref #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)