### PR TITLE
feat: add PyPI publication infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,50 @@ jobs:
       - name: Run pip-audit (fail on any vulnerability)
         run: uv run pip-audit -r requirements.txt -r requirements-dev.txt
 
+  release-gates:
+    name: release-gates
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: PyPI version gates (PRs targeting main)
+        if: github.base_ref == 'main'
+        run: |
+          python3 scripts/dev/validate_pypi_version.py --check-not-exists
+          python3 scripts/dev/validate_pypi_version.py --check-greater-than-latest
+
+      - name: Version divergence gate (PRs targeting develop)
+        if: github.base_ref == 'develop'
+        run: |
+          git fetch origin main --depth=1
+          main_version=$(python3 -c "
+          import tomllib, subprocess
+          text = subprocess.run(
+              ['git', 'show', 'origin/main:pyproject.toml'],
+              capture_output=True, text=True, check=True
+          ).stdout
+          print(tomllib.loads(text)['project']['version'])
+          ")
+          head_version=$(python3 -c "
+          import tomllib
+          from pathlib import Path
+          print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])
+          ")
+          if [ "$main_version" = "$head_version" ]; then
+            echo "FAIL: PR version ($head_version) must differ from main ($main_version)."
+            exit 1
+          fi
+          echo "OK: PR version ($head_version) differs from main ($main_version)."
+
   test-and-validate:
     name: test-and-validate
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,106 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Extract version
+        id: version
+        run: |
+          version=$(python3 -c "
+          import tomllib
+          from pathlib import Path
+          print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])
+          ")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version already on PyPI
+        id: pypi_check
+        run: |
+          status=$(python3 -c "
+          import urllib.request, urllib.error
+          try:
+              urllib.request.urlopen(
+                  'https://pypi.org/pypi/pymqrest/${{ steps.version.outputs.version }}/json',
+                  timeout=30,
+              )
+              print('exists')
+          except urllib.error.HTTPError as e:
+              print('not_found' if e.code == 404 else 'error')
+          ")
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: tag_check
+        run: |
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install uv
+        if: steps.pypi_check.outputs.status == 'not_found'
+        run: python3 -m pip install uv==0.9.26
+
+      - name: Build sdist and wheel
+        if: steps.pypi_check.outputs.status == 'not_found'
+        run: uv build --sdist --wheel
+
+      - name: Publish to PyPI
+        if: steps.pypi_check.outputs.status == 'not_found'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create git tag
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          git tag -a "${{ steps.version.outputs.tag }}" \
+            -m "Release ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub Release
+        if: steps.tag_check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "pymqrest ${{ steps.version.outputs.version }}" \
+            --notes "$(cat <<'EOF'
+          ## Installation
+
+          ```bash
+          pip install pymqrest==${{ steps.version.outputs.version }}
+          ```
+
+          ## Links
+
+          - [PyPI](https://pypi.org/project/pymqrest/${{ steps.version.outputs.version }}/)
+          - [Documentation](https://wphillipmoore.github.io/pymqrest/)
+          EOF
+          )" \
+            dist/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,10 @@ uv run mypy src/
 uv run ty check src
 ```
 
+### Publishing
+
+The `publish.yml` workflow triggers on push to `main` and publishes to PyPI via OIDC trusted publishing. It builds with `uv build`, publishes via `pypa/gh-action-pypi-publish`, creates a git tag, and a GitHub Release. The release flow is: `develop` → `release/*` → `main` (squash merge). See `docs/sphinx/development/release-workflow.md` for the full process.
+
 ### Local MQ Container
 
 For MQSC/PCF command validation against a real queue manager:

--- a/docs/sphinx/development/index.md
+++ b/docs/sphinx/development/index.md
@@ -6,4 +6,5 @@
 local-mq-container
 generation-scripts
 namespace-origin
+release-workflow
 ```

--- a/docs/sphinx/development/release-workflow.md
+++ b/docs/sphinx/development/release-workflow.md
@@ -1,0 +1,76 @@
+# Release workflow
+
+This document describes how pymqrest versions are managed and published
+to PyPI.
+
+## Version management
+
+The version is stored statically in `pyproject.toml` under
+`[project].version`. It follows semantic versioning (`MAJOR.MINOR.PATCH`)
+and is bumped manually before each release.
+
+## Release flow
+
+1. **Develop** — All feature work merges into `develop`.
+2. **Release branch** — When ready to release, create a
+   `release/X.Y.x` branch from `develop`. Bump the version in
+   `pyproject.toml` if not already done.
+3. **PR to main** — Open a pull request from the release branch to
+   `main`. CI validates version format, PyPI availability, and the full
+   test suite.
+4. **Squash merge** — Merge the PR into `main` using squash merge.
+5. **Automatic publish** — The `publish.yml` workflow fires on push to
+   `main` and:
+   - Extracts the version from `pyproject.toml`
+   - Skips if the version is already on PyPI (idempotent)
+   - Builds sdist and wheel with `uv build`
+   - Publishes to PyPI via OIDC trusted publishing
+   - Creates an annotated git tag (`vX.Y.Z`)
+   - Creates a GitHub Release with install instructions and dist
+     artifacts
+
+## CI version gates
+
+Pull requests trigger additional version checks:
+
+- **PRs targeting main**: Version must not already exist on PyPI, and
+  must be greater than the latest published version.
+- **PRs targeting develop**: Version must differ from the version on
+  `main` (prevents accidental no-op releases).
+
+## PyPI trusted publisher setup (one-time)
+
+Before the first release, the repository owner must configure OIDC
+trusted publishing on PyPI:
+
+1. Go to <https://pypi.org/manage/account/publishing/>.
+2. Add a pending publisher:
+   - **Project name**: `pymqrest`
+   - **Owner**: `wphillipmoore`
+   - **Repository**: `pymqrest`
+   - **Workflow name**: `publish.yml`
+   - **Environment**: (leave blank)
+3. The first publish will claim the package name.
+
+See the [PyPI trusted publisher documentation](https://docs.pypi.org/trusted-publishers/)
+for details.
+
+## Troubleshooting
+
+### Version already exists on PyPI
+
+The publish workflow skips publishing if the version already exists. To
+release a new version, bump the version in `pyproject.toml` and go
+through the release flow again.
+
+### Tag already exists
+
+The publish workflow skips tag creation if the tag already exists. This
+is expected when re-running a failed workflow.
+
+### Publish fails
+
+Check the workflow logs for OIDC authentication errors. Ensure the
+trusted publisher is configured correctly on PyPI. The workflow only
+triggers on push to `main`, so the `id-token: write` permission is
+scoped to that branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,26 @@ license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 authors = [{ name = "Phillip Moore", email = "w.phillip.moore@gmail.com" }]
 requires-python = ">=3.14,<4.0"
+keywords = ["ibm", "mq", "mqsc", "rest-api", "messaging", "queue-manager"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Networking",
+    "Typing :: Typed",
+]
 dependencies = [
     "requests",
 ]
+
+[project.urls]
+Homepage = "https://github.com/wphillipmoore/pymqrest"
+Documentation = "https://wphillipmoore.github.io/pymqrest/"
+Repository = "https://github.com/wphillipmoore/pymqrest"
+Issues = "https://github.com/wphillipmoore/pymqrest/issues"
 
 [dependency-groups]
 dev = [

--- a/scripts/dev/validate_pypi_version.py
+++ b/scripts/dev/validate_pypi_version.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Validate that the local version is publishable to PyPI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import ssl
+import tomllib
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+VERSION_PATTERN = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+PYPI_PROJECT_URL = "https://pypi.org/pypi/pymqrest/json"
+
+
+@dataclass(frozen=True)
+class Version:
+    """Semantic version without a build component."""
+
+    major: int
+    minor: int
+    patch: int
+
+    def as_string(self) -> str:
+        """Return the version formatted as MAJOR.MINOR.PATCH."""
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    def as_tuple(self) -> tuple[int, int, int]:
+        """Return the version as a comparison tuple."""
+        return (self.major, self.minor, self.patch)
+
+
+def parse_version(version_value: str) -> Version:
+    """Parse and validate a version string."""
+    match = VERSION_PATTERN.match(version_value)
+    if not match:
+        message = f"Invalid version format: {version_value}"
+        raise SystemExit(message)
+    major, minor, patch = (int(match.group(index)) for index in range(1, 4))
+    return Version(major=major, minor=minor, patch=patch)
+
+
+def load_local_version() -> Version:
+    """Load the version from the working tree pyproject.toml."""
+    pyproject_path = Path("pyproject.toml")
+    if not pyproject_path.is_file():
+        message = "Run from the repository root (pyproject.toml missing)."
+        raise SystemExit(message)
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project_section = data.get("project")
+    if not isinstance(project_section, dict):
+        message = "Missing [project] section in pyproject.toml."
+        raise SystemExit(message)
+    version_value = project_section.get("version")
+    if not isinstance(version_value, str):
+        message = "Missing or invalid project.version in pyproject.toml."
+        raise SystemExit(message)
+    return parse_version(version_value)
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    """Build an SSL context, using certifi CA bundle if available."""
+    try:
+        import certifi  # type: ignore[import-untyped]  # noqa: PLC0415
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
+
+
+def fetch_pypi_versions() -> list[Version] | None:
+    """Fetch all released versions from PyPI.
+
+    Returns None if the package does not exist on PyPI (404).
+    """
+    context = _build_ssl_context()
+    request = urllib.request.Request(PYPI_PROJECT_URL, headers={"Accept": "application/json"})  # noqa: S310
+    try:
+        with urllib.request.urlopen(request, timeout=30, context=context) as response:  # noqa: S310
+            data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:  # noqa: PLR2004
+            return None
+        raise
+    releases = data.get("releases", {})
+    versions: list[Version] = []
+    for version_string in releases:
+        match = VERSION_PATTERN.match(version_string)
+        if match:
+            major, minor, patch = (int(match.group(index)) for index in range(1, 4))
+            versions.append(Version(major=major, minor=minor, patch=patch))
+    return versions
+
+
+def check_not_exists(local: Version, pypi_versions: list[Version] | None) -> bool:
+    """Verify the local version is not already published on PyPI."""
+    if pypi_versions is None:
+        print(f"Package not found on PyPI; version {local.as_string()} is available.")
+        return True
+    for published in pypi_versions:
+        if published.as_tuple() == local.as_tuple():
+            print(f"FAIL: Version {local.as_string()} already exists on PyPI.")
+            return False
+    print(f"OK: Version {local.as_string()} is not yet on PyPI.")
+    return True
+
+
+def check_greater_than_latest(local: Version, pypi_versions: list[Version] | None) -> bool:
+    """Verify the local version is greater than the latest on PyPI."""
+    if pypi_versions is None:
+        print(f"Package not found on PyPI; version {local.as_string()} is the first release.")
+        return True
+    if not pypi_versions:
+        print(f"No valid releases on PyPI; version {local.as_string()} is the first release.")
+        return True
+    latest = max(pypi_versions, key=lambda v: v.as_tuple())
+    if local.as_tuple() > latest.as_tuple():
+        print(f"OK: Version {local.as_string()} > latest PyPI version {latest.as_string()}.")
+        return True
+    print(f"FAIL: Version {local.as_string()} is not greater than latest PyPI version {latest.as_string()}.")
+    return False
+
+
+def parse_arguments(argument_list: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate that the local version is publishable to PyPI.",
+    )
+    parser.add_argument(
+        "--check-not-exists",
+        action="store_true",
+        help="Verify the local version is not already on PyPI.",
+    )
+    parser.add_argument(
+        "--check-greater-than-latest",
+        action="store_true",
+        help="Verify the local version is greater than the latest on PyPI.",
+    )
+    return parser.parse_args(list(argument_list) if argument_list is not None else None)
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    if not arguments.check_not_exists and not arguments.check_greater_than_latest:
+        print("No check mode specified. Use --check-not-exists and/or --check-greater-than-latest.")
+        return 1
+
+    local_version = load_local_version()
+    pypi_versions = fetch_pypi_versions()
+
+    passed = True
+    if arguments.check_not_exists and not check_not_exists(local_version, pypi_versions):
+        passed = False
+    if arguments.check_greater_than_latest and not check_greater_than_latest(local_version, pypi_versions):
+        passed = False
+
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add PyPI package metadata (keywords, classifiers, project URLs) to `pyproject.toml`
- Create `publish.yml` workflow for OIDC trusted publishing on push to `main`
- Add `release-gates` CI job with PyPI version checks for PRs targeting `main` and version divergence checks for PRs targeting `develop`
- Create `validate_pypi_version.py` stdlib-only script with `--check-not-exists` and `--check-greater-than-latest` modes
- Add release workflow documentation and update `CLAUDE.md`

## Test plan

- [x] `validate_local.py` passes (ruff, mypy, ty, 100% coverage, markdown)
- [x] `validate_pypi_version.py --check-not-exists` confirms 0.1.0 not on PyPI
- [x] `validate_pypi_version.py --check-greater-than-latest` confirms 0.1.0 is first release
- [ ] CI passes on this PR
- [ ] After merge: configure PyPI trusted publisher before release PR

Fixes #113
Fixes #114
Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)