### PR TITLE
feat: bump version to 1.0.0, promote status to beta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Both files share the same underlying standards via include directives, ensuring 
 
 `pymqrest` is a Python wrapper for the IBM MQ administrative REST API. The project provides a Python mapping layer for MQ REST API attribute translations and command metadata experiments. The current focus is on attribute mapping and metadata modeling.
 
-**Status**: Experimental
+**Status**: Beta
 
 **Canonical Standards**: This repository follows standards at https://github.com/wphillipmoore/standards-and-conventions (local path: `../standards-and-conventions` if available)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ command metadata experiments.
 
 ## Status
 
-Experimental. The current focus is on attribute mapping and metadata modeling.
+Beta. The API surface is stable but may evolve. The current focus is on
+attribute mapping and metadata modeling.
 
 ## Development
 

--- a/docs/sphinx/design/rationale.md
+++ b/docs/sphinx/design/rationale.md
@@ -85,9 +85,8 @@ The tables contain:
 
 See {doc}`/mapping-pipeline` for full details.
 
-## Experimental status
+## Beta status
 
-`pymqrest` is experimental. The API surface, mapping tables, and return
-shapes may change. The project's primary goal is to explore whether a
-comprehensive Python mapping layer for the MQ REST API is practical and
-useful.
+`pymqrest` is in beta. The API surface, mapping tables, and return
+shapes are stable but may evolve. The project builds on an approach to
+MQ administration tooling that dates back over 25 years.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymqrest"
-version = "0.1.0"
+version = "1.0.0"
 description = "Python wrapper for the IBM MQ REST API"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -13,7 +13,7 @@ authors = [{ name = "Phillip Moore", email = "w.phillip.moore@gmail.com" }]
 requires-python = ">=3.14,<4.0"
 keywords = ["ibm", "mq", "mqsc", "rest-api", "messaging", "queue-manager"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "pymqrest"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0 to 1.0.0
- Update Development Status classifier from Alpha to Beta
- Replace "Experimental" status with "Beta" across README, CLAUDE.md, and design rationale docs
- Add `release-gates` and `standards-compliance` as required checks on both `develop` and `main` branches

## Test plan

- [x] `validate_local.py` passes
- [ ] CI passes (all 5 required checks)
- [ ] After merge: release 1.0.0 via release branch to main

Ref #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)