### PR TITLE
docs: rewrite README, fix sphinx markdown lint, close lint gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,139 @@
 # pymqrest
 
-Python wrapper for the IBM MQ REST API.
+Python wrapper for the IBM MQ administrative REST API.
+
+`pymqrest` provides typed Python methods for every MQSC command exposed
+by the IBM MQ 9.4 `runCommandJSON` REST endpoint. Attribute names are
+automatically translated between Python `snake_case` and native MQSC
+parameter names, so you work with Pythonic identifiers throughout.
 
 ## Table of Contents
 
-- [Purpose](#purpose)
-- [Status](#status)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [API overview](#api-overview)
+- [Documentation](#documentation)
 - [Development](#development)
-- [Local MQ container](#local-mq-container)
 - [License](#license)
 
-## Purpose
+## Installation
 
-Provide a Python mapping layer for MQ REST API attribute translations and
-command metadata experiments.
+```bash
+pip install pymqrest
+```
 
-## Status
+Requires Python 3.14+.
 
-Beta. The API surface is stable but may evolve. The current focus is on
-attribute mapping and metadata modeling.
+## Quick start
+
+```python
+from pymqrest import MQRESTSession, BasicAuth
+
+session = MQRESTSession(
+    rest_base_url="https://localhost:9443/ibmmq/rest/v2",
+    qmgr_name="QM1",
+    credentials=BasicAuth("mqadmin", "mqadmin"),
+    verify_tls=False,
+)
+
+# Query the queue manager
+qmgr = session.display_qmgr()
+print(qmgr["queue_manager_name"])
+
+# List all local queues
+queues = session.display_qlocal(name="*")
+for q in queues:
+    print(q["queue_name"], q.get("current_queue_depth", 0))
+
+# Idempotent object management
+result = session.ensure_qlocal(
+    name="APP.REQUESTS",
+    request_parameters={"max_queue_depth": "50000"},
+)
+print(result)  # EnsureResult.CREATED, UPDATED, or UNCHANGED
+```
+
+## API overview
+
+### Session
+
+`MQRESTSession` manages authentication, connection settings, and
+attribute mapping. All command methods are called directly on the
+session object.
+
+```python
+MQRESTSession(
+    rest_base_url="https://host:9443/ibmmq/rest/v2",
+    qmgr_name="QM1",
+    credentials=BasicAuth("user", "pass"),  # or LTPAAuth / CertificateAuth
+    map_attributes=True,      # snake_case <-> MQSC translation (default)
+    mapping_strict=True,      # raise on unknown attributes (default)
+    verify_tls=True,          # TLS certificate verification (default)
+    timeout_seconds=30.0,     # HTTP request timeout (default)
+)
+```
+
+### Commands
+
+Over 130 generated methods cover the MQSC command set:
+
+| Verb | Methods | Returns | Example |
+| --- | --- | --- | --- |
+| `display_*` | 44 | `list[dict]` or `dict \| None` | `session.display_qlocal(name="*")` |
+| `define_*` | 19 | `None` | `session.define_qlocal(name="Q1")` |
+| `alter_*` | 17 | `None` | `session.alter_qlocal(name="Q1", ...)` |
+| `delete_*` | 16 | `None` | `session.delete_qlocal(name="Q1")` |
+| Other | 41 | `None` | `start_channel`, `stop_listener`, `clear_qlocal`, ... |
+
+All methods accept optional `request_parameters` and
+`response_parameters` dicts. `DISPLAY` commands default to returning
+all attributes.
+
+### Ensure methods
+
+Idempotent `ensure_*` methods implement a declarative upsert pattern
+for 15 object types (queues, channels, topics, listeners, and more):
+
+- **DEFINE** when the object does not exist
+- **ALTER** only the attributes that differ
+- **No-op** when all specified attributes already match
+
+Returns `EnsureResult.CREATED`, `EnsureResult.UPDATED`, or
+`EnsureResult.UNCHANGED`.
+
+### Attribute mapping
+
+When `map_attributes=True` (the default), attribute names and values
+are translated automatically:
+
+| Direction | From | To | Example |
+| --- | --- | --- | --- |
+| Request | `max_queue_depth` | `MAXDEPTH` | snake_case to MQSC |
+| Response | `MAXDEPTH` | `max_queue_depth` | MQSC to snake_case |
+
+Disable per-session (`map_attributes=False`) or per-call for raw MQSC
+parameter access.
+
+### Authentication
+
+Three credential types are supported:
+
+- `BasicAuth(username, password)` — HTTP Basic authentication
+- `LTPAAuth(username, password)` — LTPA token login (automatic at
+  session creation)
+- `CertificateAuth(cert_path, key_path)` — mutual TLS client
+  certificates
+
+## Documentation
+
+Full documentation: <https://wphillipmoore.github.io/pymqrest/>
 
 ## Development
-
-Set up the environment and run the canonical validation command:
 
 ```bash
 uv sync --group dev
 uv run python3 scripts/dev/validate_local.py
 ```
-
-Docs-only changes can use:
-
-```bash
-uv run python3 scripts/dev/validate_docs.py
-```
-
-## Local MQ container
-
-For local MQSC/PCF command validation against a real queue manager, see
-`docs/mq-container-local-dev.md`.
 
 ## License
 

--- a/docs/sphinx/ai-engineering.md
+++ b/docs/sphinx/ai-engineering.md
@@ -81,7 +81,7 @@ assumptions hold against actual MQ responses.
 Commits that involved AI assistance include a `Co-Authored-By` trailer
 identifying the agent used:
 
-```
+```text
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 Co-Authored-By: Codex <noreply@openai.com>
 ```

--- a/docs/sphinx/api/exceptions.md
+++ b/docs/sphinx/api/exceptions.md
@@ -2,7 +2,7 @@
 
 All exceptions inherit from `MQRESTError`.
 
-```
+```text
 Exception
 └── MQRESTError
     ├── MQRESTAuthError        — authentication failures

--- a/docs/sphinx/architecture.md
+++ b/docs/sphinx/architecture.md
@@ -35,7 +35,7 @@
 
 Every MQSC command follows the same path through the system:
 
-```
+```text
 Method call (e.g. display_queue)
   → _mqsc_command()
     → Map request attributes (snake_case → MQSC)
@@ -64,15 +64,15 @@ Method call (e.g. display_queue)
 
 ### Parse phase
 
-6. The JSON response is parsed and validated.
-7. Error codes (`overallCompletionCode`, `overallReasonCode`, per-item
+1. The JSON response is parsed and validated.
+2. Error codes (`overallCompletionCode`, `overallReasonCode`, per-item
    `completionCode`/`reasonCode`) are checked. Errors raise
    `MQRESTCommandError`.
-8. The `parameters` dict is extracted from each `commandResponse` item.
-9. Nested `objects` lists (e.g. from `DISPLAY CONN TYPE(HANDLE)`) are
+3. The `parameters` dict is extracted from each `commandResponse` item.
+4. Nested `objects` lists (e.g. from `DISPLAY CONN TYPE(HANDLE)`) are
    flattened into the parent parameter set.
-10. If mapping is enabled, response attributes are translated from MQSC
-    to `snake_case`.
+5. If mapping is enabled, response attributes are translated from MQSC
+   to `snake_case`.
 
 ## Transport abstraction
 
@@ -99,7 +99,7 @@ library. Tests inject a mock transport to avoid network calls.
 
 All MQSC operations go through a single REST endpoint:
 
-```
+```text
 POST /ibmmq/rest/v2/admin/action/qmgr/{qmgr}/mqsc
 ```
 

--- a/docs/sphinx/design/rationale.md
+++ b/docs/sphinx/design/rationale.md
@@ -15,7 +15,7 @@ errors as exceptions with full diagnostic context.
 
 All MQSC operations go through a single REST endpoint:
 
-```
+```text
 POST /ibmmq/rest/v2/admin/action/qmgr/{qmgr}/mqsc
 ```
 

--- a/docs/sphinx/design/runcommand-endpoint.md
+++ b/docs/sphinx/design/runcommand-endpoint.md
@@ -5,7 +5,7 @@
 The IBM MQ administrative REST API provides a `runCommandJSON` endpoint
 that accepts MQSC commands as structured JSON:
 
-```
+```text
 POST /ibmmq/rest/v2/admin/action/qmgr/{qmgr}/mqsc
 ```
 


### PR DESCRIPTION
## Summary

- Rewrite README with installation, quick start, API overview (session, commands, ensure methods, attribute mapping, authentication), and documentation links — serves as the PyPI landing page
- Fix 11 markdownlint violations in `docs/sphinx/` (MD040 fenced-code-language, MD029 ordered-list-prefix)
- Update `markdown-standards.sh` to run markdownlint on `docs/sphinx/` files while skipping structural checks (Table of Contents, single-H1) that do not apply to MyST/Sphinx pages — closes the lint coverage gap that allowed these errors to accumulate

Ref #113

## Test plan

- [ ] `uv run python3 scripts/dev/validate_local.py` passes (all checks including markdown lint)
- [ ] `uv run python3 scripts/dev/validate_docs.py` passes (no markdown errors in docs/sphinx/)
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)