### PR TITLE
feat: auto-bump patch version after publish, bump to 1.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 concurrency:
   group: publish
@@ -128,3 +129,68 @@ jobs:
           EOF
           )"
           fi
+
+      - name: Compute next patch version
+        id: next_version
+        run: |
+          next=$(python3 -c "
+          v = '${{ steps.version.outputs.version }}'.split('.')
+          v[2] = str(int(v[2]) + 1)
+          print('.'.join(v))
+          ")
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+          echo "branch=chore/bump-version-$next" >> "$GITHUB_OUTPUT"
+
+      - name: Check if develop already has next version
+        id: bump_check
+        run: |
+          git fetch origin develop
+          current=$(git show origin/develop:pyproject.toml | python3 -c "
+          import sys, tomllib
+          print(tomllib.loads(sys.stdin.read())['project']['version'])
+          ")
+          if [ "$current" = "${{ steps.next_version.outputs.version }}" ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create version bump PR
+        if: steps.bump_check.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git checkout -b "${{ steps.next_version.outputs.branch }}" origin/develop
+
+          python3 -c "
+          from pathlib import Path
+          import re
+          p = Path('pyproject.toml')
+          content = p.read_text()
+          content = re.sub(
+              r'^(version\s*=\s*\").*(\"\s*)$',
+              r'\g<1>${{ steps.next_version.outputs.version }}\2',
+              content,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          p.write_text(content)
+          "
+
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${{ steps.next_version.outputs.version }}"
+          git push origin "${{ steps.next_version.outputs.branch }}"
+
+          gh pr create \
+            --base develop \
+            --head "${{ steps.next_version.outputs.branch }}" \
+            --title "chore: bump version to ${{ steps.next_version.outputs.version }}" \
+            --body "$(cat <<'EOF'
+          Automated patch version bump after publishing ${{ steps.version.outputs.version }}.
+
+          This sets the working version to the next expected patch release.
+          Change this to a minor or major bump if the next release warrants it.
+
+          Ref #113
+          EOF
+          )"

--- a/docs/sphinx/development/release-workflow.md
+++ b/docs/sphinx/development/release-workflow.md
@@ -6,8 +6,11 @@ to PyPI.
 ## Version management
 
 The version is stored statically in `pyproject.toml` under
-`[project].version`. It follows semantic versioning (`MAJOR.MINOR.PATCH`)
-and is bumped manually before each release.
+`[project].version`. It follows semantic versioning (`MAJOR.MINOR.PATCH`).
+
+After each release, the publish workflow automatically opens a PR to
+bump the patch version on `develop`. This default can be overridden at
+any time by changing the version to a minor or major bump instead.
 
 ## Release flow
 
@@ -28,6 +31,21 @@ and is bumped manually before each release.
    - Creates an annotated git tag (`vX.Y.Z`)
    - Creates a GitHub Release with install instructions and dist
      artifacts
+   - Opens a PR against `develop` to bump the patch version (e.g.
+     `1.0.0` → `1.0.1`), assuming the next release is a patch
+
+## Automatic version bump
+
+After each successful publish, the workflow creates a PR to increment
+the patch version on `develop`. This keeps the working version ahead of
+the last release and ready for the next patch.
+
+If the next release should be a minor or major bump instead, simply
+change the version in `pyproject.toml` at any point during the
+development cycle — the automated PR is just a default starting point.
+
+The bump PR is skipped if `develop` already has the expected next
+version (e.g. if someone bumped it manually first).
 
 ## CI version gates
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymqrest"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python wrapper for the IBM MQ REST API"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "pymqrest"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

- After a successful PyPI publish, the workflow creates a PR against `develop` to increment the patch version (e.g. `1.0.0` → `1.0.1`)
- Assumes the next release is a patch — the version can be changed to a minor or major bump at any point during the development cycle
- Skipped if `develop` already has the expected next version
- Added `pull-requests: write` permission to the publish workflow
- Updated release workflow docs to describe the automatic version bump
- Bumps version `1.0.0` → `1.0.1` to bootstrap the workflow (satisfies the version divergence gate)

Ref #113

## Test plan

- [ ] CI passes all gates (including release-gates version divergence)
- [ ] Next publish to main triggers the version bump PR on develop
- [ ] If develop already has the bumped version, the step is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)