### PR TITLE
feat: add changelog with git-cliff and CI validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,10 @@ jobs:
           python3 scripts/dev/validate_pypi_version.py --check-not-exists
           python3 scripts/dev/validate_pypi_version.py --check-greater-than-latest
 
+      - name: Changelog version gate (PRs targeting main)
+        if: github.base_ref == 'main'
+        run: python3 scripts/dev/validate_changelog.py
+
       - name: Version divergence gate (PRs targeting develop)
         if: github.base_ref == 'develop'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,13 @@ jobs:
             -m "Release ${{ steps.version.outputs.version }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
+      - name: Tag develop for changelog boundaries
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          git fetch origin develop
+          git tag "develop-${{ steps.version.outputs.tag }}" origin/develop
+          git push origin "develop-${{ steps.version.outputs.tag }}"
+
       - name: Create GitHub Release
         if: steps.tag_check.outputs.exists == 'false'
         env:

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,4 @@
 {
-  "MD013": false
+  "MD013": false,
+  "MD024": { "siblings_only": true }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,115 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Features
+
+- auto-bump patch version after publish, bump to 1.0.1 (#147)
+
+## [1.0.0] - 2026-02-10
+
+### Documentation
+
+- rewrite README, fix sphinx markdown lint, close lint coverage gap (#145)
+
+### Features
+
+- bump version to 1.0.0, promote status from experimental to beta (#144)
+
+## [0.1.0] - 2026-02-10
+
+### Bug fixes
+
+- prevent docs-only merge-base failures
+- make docs-only detection merge-base independent
+- satisfy ruff checks for metadata refresh script
+- update include directives
+- harden response parameter mapping
+- standardize shared MQSC attribute mappings
+- standardize additional shared attributes
+- standardize CFSTRUCT and CLWL mappings
+- correct ClusterWorkloadRank mapping
+- standardize DESCR mapping
+- enforce per-qualifier unique mappings
+- normalize client/message/user mappings
+- standardize identifiers and LIKE mapping
+- normalize QMgr and Like mappings
+- normalize Like and QMgr identifiers
+- clean stgclass Like override
+- normalize SSLPEER and cfstatus recovery mappings
+- normalize cfstatus recovery fields
+- normalize CLWL PCF names (issue #88)
+- expand Msg to Message in PCF overrides (issue #87)
+- normalize Identifier to Id (issue #86)
+- normalize CFStructType override (issue #82)
+- remove name parameter from QMGR and CMDSERV command methods (#100)
+- omit responseParameters from non-DISPLAY commands to prevent silent failures (#125)
+- configure git identity for annotated tag creation in publish workflow (#143)
+
+### Documentation
+
+- align repo docs with standards (#12)
+- align standards entrypoint with repo type
+- adopt standards include bootstrap
+- align standards includes
+- require uv run for python commands
+- archive first-pass docs and capture mqsc list (#70)
+- regroup conflicts report
+- note codex command policy workaround
+- add CLAUDE.md for Claude Code integration (#96)
+- document standards compliance gates implementation (#99)
+- add Sphinx documentation tree with mapping reference and API docs (#30) (#105)
+- rework API reference pages for readability (#108)
+- enrich docstrings for session, mapping, and exception modules (#111)
+- add docstrings to all MQSC command wrapper methods (#109) (#116)
+- fix autodoc rendering by wrapping directives in eval-rst blocks (#117)
+- credit both Claude Code and Codex in AI engineering page (#118)
+- separate unmapped qualifiers in mapping index, rewrite auth docs (#135)
+- remove misleading "yet" from unmapped qualifier description (#137)
+- clarify mapping data is bootstrapped from 9.4 docs, now authoritative in source (#141)
+
+### Features
+
+- add mq container tooling and refresh mqsc output metadata
+- add MQ REST session framework
+- switch session transport to requests
+- add more MQSC helper methods
+- expand MQSC command wrappers
+- add MQSC qualifier placeholders
+- support request key/value mappings
+- document response parameter macros (issue #84)
+- enable strict attribute mapping by default (#98)
+- add WHERE filter support for DISPLAY commands (#101)
+- flatten nested objects in command response parameters (#103)
+- add practical example scripts with multi-QM Docker environment (#104) (#119)
+- add idempotent ensure methods for declarative object management (#75) (#121)
+- add ensure_qmgr for idempotent queue manager attribute management (#123)
+- add LTPA token and mTLS client certificate authentication (#131)
+- add PyPI publication infrastructure (#142)
+
+### Refactoring
+
+- remove explicit channel_type arg
+- move mq rest exceptions to module
+- move MQSC command methods to commands module
+- rename _build_response_parameter_map to _build_snake_to_mqsc_map (#102)
+- expand opaque MQSC shorthands to descriptive snake_case names (#126)
+- expand abbreviated snake_case attribute names to descriptive forms (#127)
+- expand remaining abbreviated snake_case attribute names (#128)
+- expand abbreviated snake_case attribute names (batch 4) (#132)
+- use snake_case attribute names exclusively in examples (#133)
+- require credentials keyword argument, drop username/password (#134)
+- make perform_ltpa_login internal, remove from public docs (#136)
+- archive extraction pipeline, use MAPPING_DATA as sole source of truth (#140)
+
+### Testing
+
+- cover MQREST session helpers
+- expand integration display coverage
+- generalize integration display and mutating coverage
+- run integration lifecycle against local mq

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+"""
+body = """
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="develop-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | trim }}\
+    {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug fixes" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "develop-v[0-9].*"
+skip_tags = ""
+sort_commits = "oldest"

--- a/docs/sphinx/development/release-workflow.md
+++ b/docs/sphinx/development/release-workflow.md
@@ -18,17 +18,29 @@ any time by changing the version to a minor or major bump instead.
 2. **Release branch** — When ready to release, create a
    `release/X.Y.x` branch from `develop`. Bump the version in
    `pyproject.toml` if not already done.
-3. **PR to main** — Open a pull request from the release branch to
-   `main`. CI validates version format, PyPI availability, and the full
-   test suite.
-4. **Squash merge** — Merge the PR into `main` using squash merge.
-5. **Automatic publish** — The `publish.yml` workflow fires on push to
+3. **Update changelog** — Run git-cliff to update `CHANGELOG.md` with
+   the new version heading:
+
+   ```bash
+   git-cliff --tag develop-vX.Y.Z -o CHANGELOG.md
+   ```
+
+   Review the generated changelog, commit it, and push to the release
+   branch. The CI changelog gate will verify that `CHANGELOG.md`
+   contains an entry matching the version in `pyproject.toml`.
+4. **PR to main** — Open a pull request from the release branch to
+   `main`. CI validates version format, PyPI availability, changelog
+   entry, and the full test suite.
+5. **Squash merge** — Merge the PR into `main` using squash merge.
+6. **Automatic publish** — The `publish.yml` workflow fires on push to
    `main` and:
    - Extracts the version from `pyproject.toml`
    - Skips if the version is already on PyPI (idempotent)
    - Builds sdist and wheel with `uv build`
    - Publishes to PyPI via OIDC trusted publishing
    - Creates an annotated git tag (`vX.Y.Z`)
+   - Creates a `develop-vX.Y.Z` lightweight tag on `develop` for
+     git-cliff boundary tracking
    - Creates a GitHub Release with install instructions and dist
      artifacts
    - Opens a PR against `develop` to bump the patch version (e.g.
@@ -47,12 +59,53 @@ development cycle — the automated PR is just a default starting point.
 The bump PR is skipped if `develop` already has the expected next
 version (e.g. if someone bumped it manually first).
 
+## Changelog
+
+The project changelog is maintained in `CHANGELOG.md` using
+[git-cliff](https://git-cliff.org/), configured via `cliff.toml` at
+the repository root.
+
+git-cliff is a local developer tool (not required in CI). Install it
+with Homebrew:
+
+```bash
+brew install git-cliff
+```
+
+### How it works
+
+git-cliff uses `develop-vX.Y.Z` lightweight tags as version boundary
+markers. These tags point to commits on `develop` and are created
+automatically by the publish workflow after each release. They allow
+git-cliff to determine which commits belong to each version when run
+on `develop` or a release branch.
+
+To regenerate the changelog from scratch:
+
+```bash
+git-cliff -o CHANGELOG.md
+```
+
+To generate the changelog with a new version heading (used during the
+release flow):
+
+```bash
+git-cliff --tag develop-vX.Y.Z -o CHANGELOG.md
+```
+
+### CI validation
+
+The `release-gates` CI job validates that `CHANGELOG.md` contains an
+entry matching the version in `pyproject.toml` for PRs targeting
+`main`. This ensures the changelog is always updated before a release.
+
 ## CI version gates
 
 Pull requests trigger additional version checks:
 
-- **PRs targeting main**: Version must not already exist on PyPI, and
-  must be greater than the latest published version.
+- **PRs targeting main**: Version must not already exist on PyPI, must
+  be greater than the latest published version, and `CHANGELOG.md`
+  must contain an entry for the version.
 - **PRs targeting develop**: Version must differ from the version on
   `main` (prevents accidental no-op releases).
 

--- a/scripts/dev/validate_changelog.py
+++ b/scripts/dev/validate_changelog.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Validate that CHANGELOG.md contains an entry for the current version."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+
+def load_version() -> str:
+    """Load the version from pyproject.toml."""
+    pyproject_path = Path("pyproject.toml")
+    if not pyproject_path.is_file():
+        message = "Run from the repository root (pyproject.toml missing)."
+        raise SystemExit(message)
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project_section = data.get("project")
+    if not isinstance(project_section, dict):
+        message = "Missing [project] section in pyproject.toml."
+        raise SystemExit(message)
+    version_value = project_section.get("version")
+    if not isinstance(version_value, str):
+        message = "Missing or invalid project.version in pyproject.toml."
+        raise SystemExit(message)
+    return version_value
+
+
+def main() -> int:
+    version = load_version()
+
+    changelog_path = Path("CHANGELOG.md")
+    if not changelog_path.is_file():
+        print(f"FAIL: CHANGELOG.md not found (expected entry for {version}).")
+        return 1
+
+    content = changelog_path.read_text(encoding="utf-8")
+    pattern = re.compile(rf"^## \[{re.escape(version)}\]", re.MULTILINE)
+
+    if pattern.search(content):
+        print(f"OK: CHANGELOG.md contains entry for {version}.")
+        return 0
+
+    print(f"FAIL: CHANGELOG.md has no entry for {version}.")
+    print("Run git-cliff to update the changelog before releasing.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint/markdown-standards.sh
+++ b/scripts/lint/markdown-standards.sh
@@ -11,10 +11,6 @@ if [[ -f README.md ]]; then
   files+=("README.md")
 fi
 
-if [[ -f CHANGELOG.md ]]; then
-  files+=("CHANGELOG.md")
-fi
-
 # Collect Sphinx docs (markdownlint only — structural checks like
 # Table of Contents and single-H1 do not apply to MyST/Sphinx pages).
 sphinx_files=()
@@ -25,6 +21,12 @@ if [[ -d docs/sphinx ]]; then
 fi
 
 all_files=("${files[@]}" "${sphinx_files[@]}")
+
+# CHANGELOG.md gets markdownlint only — no structural checks (no TOC,
+# multiple H2 headings are expected, heading hierarchy differs).
+if [[ -f CHANGELOG.md ]]; then
+  all_files+=("CHANGELOG.md")
+fi
 
 if [[ ${#all_files[@]} -eq 0 ]]; then
   echo "ERROR: no markdown files found to lint." >&2


### PR DESCRIPTION
## Summary

- Add git-cliff changelog generation with `cliff.toml` config and seeded `CHANGELOG.md` for v0.1.0 and v1.0.0
- Add `validate_changelog.py` CI gate requiring changelog entries for PRs targeting `main`
- Publish workflow now creates `develop-vX.Y.Z` lightweight tags for git-cliff version boundaries
- Exempt `CHANGELOG.md` from structural markdown checks (TOC, single-H1) while keeping markdownlint

## Test plan

- [x] `uv run python3 scripts/dev/validate_local.py` passes
- [x] `markdownlint --config .markdownlint.json CHANGELOG.md` passes
- [x] `python3 scripts/dev/validate_changelog.py` correctly fails (1.0.1 not yet in changelog — expected on develop)
- [x] `git-cliff --tag develop-v1.0.1` correctly produces `## [1.0.1]` heading
- [x] `develop-v0.1.0` and `develop-v1.0.0` tags pushed to remote

Ref #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)