### PR TITLE
fix: resolve bare branch names to origin/ in commit-messages.sh

### DIFF
--- a/scripts/lint/commit-messages.sh
+++ b/scripts/lint/commit-messages.sh
@@ -10,6 +10,13 @@ if [[ -z "$base_ref" || -z "$head_ref" ]]; then
   exit 2
 fi
 
+# Resolve bare branch names to origin/ when the local branch doesn't exist.
+if ! git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
+  if git rev-parse --verify --quiet "origin/$base_ref" >/dev/null 2>&1; then
+    base_ref="origin/$base_ref"
+  fi
+fi
+
 conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
 
 failed=0


### PR DESCRIPTION
## Summary

- When `commit-messages.sh` receives a bare branch name (e.g. `main`) that doesn't exist locally, resolve it to `origin/main` before running `git rev-list`
- Eliminates the `fatal: ambiguous argument 'main..HEAD'` warning during local validation

## Test plan

- [x] `uv run python3 scripts/dev/validate_local.py` passes with no `fatal:` warnings

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)