### PR TITLE
feat: add prepare_release.py to automate release preparation

### DIFF
--- a/docs/sphinx/development/release-workflow.md
+++ b/docs/sphinx/development/release-workflow.md
@@ -14,25 +14,26 @@ any time by changing the version to a minor or major bump instead.
 
 ## Release flow
 
-1. **Develop** — All feature work merges into `develop`.
-2. **Release branch** — When ready to release, create a
-   `release/X.Y.x` branch from `develop`. Bump the version in
-   `pyproject.toml` if not already done.
-3. **Update changelog** — Run git-cliff to update `CHANGELOG.md` with
-   the new version heading:
+1. **Develop** — All feature work merges into `develop`. Ensure the
+   version in `pyproject.toml` is set to the desired release version.
+2. **Prepare release** — Run the release preparation script from
+   `develop`:
 
    ```bash
-   git-cliff --tag develop-vX.Y.Z -o CHANGELOG.md
+   uv run python3 scripts/dev/prepare_release.py
    ```
 
-   Review the generated changelog, commit it, and push to the release
-   branch. The CI changelog gate will verify that `CHANGELOG.md`
-   contains an entry matching the version in `pyproject.toml`.
-4. **PR to main** — Open a pull request from the release branch to
-   `main`. CI validates version format, PyPI availability, changelog
-   entry, and the full test suite.
-5. **Squash merge** — Merge the PR into `main` using squash merge.
-6. **Automatic publish** — The `publish.yml` workflow fires on push to
+   The script automates everything needed to get a release PR open:
+   - Validates preconditions (on `develop`, clean tree, tools available)
+   - Creates a `release/X.Y.x` branch
+   - Generates the changelog via git-cliff
+   - Commits the changelog update
+   - Pushes the branch and creates a PR to `main`
+   - Enables auto-merge (squash, delete branch)
+
+3. **Squash merge** — The PR merges automatically once CI passes.
+   If auto-merge is not enabled on the repository, merge manually.
+4. **Automatic publish** — The `publish.yml` workflow fires on push to
    `main` and:
    - Extracts the version from `pyproject.toml`
    - Skips if the version is already on PyPI (idempotent)

--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Automate release preparation: branch, changelog, commit, PR, auto-merge."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def read_command_output(command: tuple[str, ...]) -> str:
+    """Run a command and return its stdout."""
+    result = subprocess.run(command, check=True, text=True, capture_output=True)  # noqa: S603
+    return result.stdout.strip()
+
+
+def run_command(command: tuple[str, ...]) -> None:
+    """Run a command and raise on failure."""
+    subprocess.run(command, check=True)  # noqa: S603
+
+
+def ensure_project_root() -> None:
+    """Fail fast if invoked outside the repository root."""
+    if not Path("pyproject.toml").is_file():
+        message = "Run from the repository root (pyproject.toml missing)."
+        raise SystemExit(message)
+
+
+def read_version() -> str:
+    """Read the version string from pyproject.toml."""
+    text = Path("pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        message = "Could not find version in pyproject.toml."
+        raise SystemExit(message)
+    return match.group(1)
+
+
+def ensure_on_develop() -> None:
+    """Fail if not on the develop branch."""
+    branch = read_command_output(("git", "rev-parse", "--abbrev-ref", "HEAD"))
+    if branch != "develop":
+        message = f"Must be on develop branch (currently on '{branch}')."
+        raise SystemExit(message)
+
+
+def ensure_clean_tree() -> None:
+    """Fail if the working tree has uncommitted changes."""
+    status = read_command_output(("git", "status", "--porcelain"))
+    if status:
+        message = "Working tree is not clean. Commit or stash changes first."
+        raise SystemExit(message)
+
+
+def ensure_tool_available(name: str) -> None:
+    """Fail if a required tool is not on PATH."""
+    if not shutil.which(name):
+        message = f"Required tool '{name}' not found on PATH."
+        raise SystemExit(message)
+
+
+def branch_exists(name: str) -> bool:
+    """Return True if a branch exists locally or on origin."""
+    for ref in (name, f"origin/{name}"):
+        result = subprocess.run(  # noqa: S603
+            ("git", "rev-parse", "--verify", "--quiet", ref),
+            check=False,
+        )
+        if result.returncode == 0:
+            return True
+    return False
+
+
+def create_release_branch(branch: str) -> None:
+    """Create and switch to the release branch."""
+    if branch_exists(branch):
+        message = f"Release branch '{branch}' already exists."
+        raise SystemExit(message)
+    print(f"Creating branch: {branch}")
+    run_command(("git", "checkout", "-b", branch))
+
+
+def generate_changelog(version: str) -> None:
+    """Run git-cliff to regenerate CHANGELOG.md."""
+    tag = f"develop-v{version}"
+    print(f"Generating changelog with tag: {tag}")
+    run_command(("git-cliff", "--tag", tag, "-o", "CHANGELOG.md"))
+
+
+def commit_changelog(version: str) -> None:
+    """Stage and commit the changelog."""
+    run_command(("git", "add", "CHANGELOG.md"))
+    run_command(("git", "commit", "-m", f"docs: update changelog for {version}"))
+
+
+def push_branch(branch: str) -> None:
+    """Push the release branch to origin."""
+    print(f"Pushing branch: {branch}")
+    run_command(("git", "push", "-u", "origin", branch))
+
+
+def create_pr(version: str) -> str:
+    """Create a PR to main and return the PR URL."""
+    print("Creating pull request to main...")
+    title = f"release: {version}"
+    body = (
+        "## Summary\n"
+        f"- Release {version} to PyPI\n"
+        "- Changelog updated via git-cliff\n"
+        "\n"
+        "Ref #113\n"
+        "\n"
+        "\U0001f916 Generated with `prepare_release.py`\n"
+    )
+    result = subprocess.run(  # noqa: S603
+        (
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            "main",
+            "--title",
+            title,
+            "--body",
+            body,
+        ),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    url = result.stdout.strip()
+    print(f"PR created: {url}")
+    return url
+
+
+def enable_auto_merge(url: str) -> None:
+    """Enable auto-merge on the PR."""
+    print("Enabling auto-merge...")
+    run_command(("gh", "pr", "merge", url, "--auto", "--squash", "--delete-branch"))
+
+
+def main() -> int:
+    ensure_project_root()
+    ensure_on_develop()
+    ensure_clean_tree()
+    ensure_tool_available("git-cliff")
+    ensure_tool_available("gh")
+
+    version = read_version()
+    parts = version.split(".")
+    branch = f"release/{parts[0]}.{parts[1]}.x"
+
+    print(f"Preparing release {version}")
+
+    create_release_branch(branch)
+    generate_changelog(version)
+    commit_changelog(version)
+    push_branch(branch)
+    url = create_pr(version)
+    enable_auto_merge(url)
+
+    print(f"Release {version} preparation complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add `scripts/dev/prepare_release.py` to automate the full release preparation sequence (branch, changelog, commit, PR, auto-merge)
- Update release workflow docs to replace manual steps 2–4 with a single script invocation

Ref #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)