### PR TITLE
fix: use full version in release branch name to avoid collisions

### DIFF
--- a/docs/sphinx/development/release-workflow.md
+++ b/docs/sphinx/development/release-workflow.md
@@ -25,7 +25,7 @@ any time by changing the version to a minor or major bump instead.
 
    The script automates everything needed to get a release PR open:
    - Validates preconditions (on `develop`, clean tree, tools available)
-   - Creates a `release/X.Y.x` branch
+   - Creates a `release/X.Y.Z` branch
    - Generates the changelog via git-cliff
    - Commits the changelog update
    - Pushes the branch and creates a PR to `main`

--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -148,8 +148,7 @@ def main() -> int:
     ensure_tool_available("gh")
 
     version = read_version()
-    parts = version.split(".")
-    branch = f"release/{parts[0]}.{parts[1]}.x"
+    branch = f"release/{version}"
 
     print(f"Preparing release {version}")
 


### PR DESCRIPTION
## Summary

- Change release branch naming from `release/X.Y.x` to `release/X.Y.Z`
- `release/X.Y.x` collides across patch releases because `--delete-branch` only fires after merge
- Each release now gets a unique branch name matching its version

Ref #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)