### PR TITLE
fix: merge main into release branch to reconcile squash-merge history

### DIFF
--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -73,12 +73,15 @@ def branch_exists(name: str) -> bool:
 
 
 def create_release_branch(branch: str) -> None:
-    """Create and switch to the release branch."""
+    """Create the release branch and merge main to reconcile histories."""
     if branch_exists(branch):
         message = f"Release branch '{branch}' already exists."
         raise SystemExit(message)
     print(f"Creating branch: {branch}")
     run_command(("git", "checkout", "-b", branch))
+    print("Merging origin/main to reconcile squash-merge history...")
+    run_command(("git", "fetch", "origin", "main"))
+    run_command(("git", "merge", "origin/main", "--strategy=ours", "--no-edit", "-m", "merge main into release branch"))
 
 
 def generate_changelog(version: str) -> None:


### PR DESCRIPTION
## Summary

- After creating the release branch from develop, merge `origin/main` with `--strategy=ours` to reconcile squash-merge history divergence
- Without this, release PRs to main always conflict because squash merges create divergent commit histories

Ref #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)