### PR TITLE
fix: use regular merge for release PRs and refresh deps in version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,7 +184,11 @@ jobs:
           p.write_text(content)
           "
 
-          git add pyproject.toml
+          uv lock --upgrade
+          uv export --no-hashes -o requirements.txt
+          uv export --no-hashes --group dev -o requirements-dev.txt
+
+          git add pyproject.toml uv.lock requirements.txt requirements-dev.txt
           git commit -m "chore: bump version to ${{ steps.next_version.outputs.version }}"
           git push origin "${{ steps.next_version.outputs.branch }}"
 
@@ -197,6 +201,9 @@ jobs:
 
           This sets the working version to the next expected patch release.
           Change this to a minor or major bump if the next release warrants it.
+
+          Dependencies are refreshed to their latest compatible versions
+          via `uv lock --upgrade`.
 
           Ref #113
           EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ uv run ty check src
 
 ### Publishing
 
-The `publish.yml` workflow triggers on push to `main` and publishes to PyPI via OIDC trusted publishing. It builds with `uv build`, publishes via `pypa/gh-action-pypi-publish`, creates a git tag, and a GitHub Release. The release flow is: `develop` → `release/*` → `main` (squash merge). See `docs/sphinx/development/release-workflow.md` for the full process.
+The `publish.yml` workflow triggers on push to `main` and publishes to PyPI via OIDC trusted publishing. It builds with `uv build`, publishes via `pypa/gh-action-pypi-publish`, creates a git tag, and a GitHub Release. The release flow is: `develop` → `release/*` → `main` (merge commit). See `docs/sphinx/development/release-workflow.md` for the full process.
 
 ### Local MQ Container
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -60,8 +60,12 @@ Required for integration testing:
 
 ## Merge strategy override
 
-- This repository uses squash merges (`--squash`) instead of the canonical default (`--merge`).
-- Use `gh pr merge --auto --squash --delete-branch` for auto-merge.
+- Feature, bugfix, and chore PRs targeting `develop` use squash merges (`--squash`).
+- Release PRs targeting `main` use regular merges (`--merge`) to preserve shared
+  ancestry between `main` and `develop`.
+- Auto-merge commands:
+  - Feature PRs: `gh pr merge --auto --squash --delete-branch`
+  - Release PRs: `gh pr merge --auto --merge --delete-branch`
 
 ## Temporary tooling workaround
 

--- a/docs/sphinx/development/release-workflow.md
+++ b/docs/sphinx/development/release-workflow.md
@@ -25,14 +25,17 @@ any time by changing the version to a minor or major bump instead.
 
    The script automates everything needed to get a release PR open:
    - Validates preconditions (on `develop`, clean tree, tools available)
-   - Creates a `release/X.Y.Z` branch
+   - Creates a `release/X.Y.Z` branch from `develop`
    - Generates the changelog via git-cliff
-   - Commits the changelog update
+   - Commits the changelog update on the release branch
    - Pushes the branch and creates a PR to `main`
-   - Enables auto-merge (squash, delete branch)
+   - Enables auto-merge (regular merge, delete branch)
 
-3. **Squash merge** — The PR merges automatically once CI passes.
-   If auto-merge is not enabled on the repository, merge manually.
+3. **Merge to main** — The PR merges automatically once CI passes
+   using a regular merge commit (not squash). This preserves shared
+   ancestry between `main` and `develop`, avoiding history divergence.
+   If auto-merge is not enabled on the repository, merge manually
+   with `--merge`.
 4. **Automatic publish** — The `publish.yml` workflow fires on push to
    `main` and:
    - Extracts the version from `pyproject.toml`
@@ -51,7 +54,10 @@ any time by changing the version to a minor or major bump instead.
 
 After each successful publish, the workflow creates a PR to increment
 the patch version on `develop`. This keeps the working version ahead of
-the last release and ready for the next patch.
+the last release and ready for the next patch. The bump PR also
+refreshes all dependencies to their latest compatible versions via
+`uv lock --upgrade` and re-exports `requirements.txt` and
+`requirements-dev.txt`.
 
 If the next release should be a minor or major bump instead, simply
 change the version in `pyproject.toml` at any point during the

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -16,8 +16,8 @@ case "$current_branch" in
     ;;
 esac
 
-if [[ ! "$current_branch" =~ ^(feature|bugfix|hotfix|release)/.+$ ]]; then
+if [[ ! "$current_branch" =~ ^(feature|bugfix|hotfix|release|chore)/.+$ ]]; then
   echo "ERROR: branch '$current_branch' does not follow the required prefix rules." >&2
-  echo "Allowed prefixes: feature/*, bugfix/*, hotfix/*, release/*" >&2
+  echo "Allowed prefixes: feature/*, bugfix/*, hotfix/*, release/*, chore/*" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Switch release PRs (release/* to main) from squash merge to regular merge commit, preserving shared ancestry between main and develop and eliminating the commit-tree workaround in prepare_release.py
- Post-publish version bump PR now runs uv lock --upgrade and re-exports requirements.txt / requirements-dev.txt
- Allow chore/* branch prefix in pre-commit hook

## Test plan

- [x] uv run python3 scripts/dev/validate_local.py passes (verified locally)
- [ ] Review simplified prepare_release.py flow
- [ ] Verify publish.yml dependency refresh steps
- [ ] Full integration test on next actual release cycle

Fixes #173