### PR TITLE
docs: use LTPAAuth as default in examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ parameter names, so you work with Pythonic identifiers throughout.
 pip install pymqrest
 ```
 
-Requires Python 3.14+.
+Requires Python 3.12+.
 
 ## Quick start
 
 ```python
-from pymqrest import MQRESTSession, BasicAuth
+from pymqrest import MQRESTSession, LTPAAuth
 
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    credentials=BasicAuth("mqadmin", "mqadmin"),
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
     verify_tls=False,
 )
 
@@ -65,7 +65,7 @@ session object.
 MQRESTSession(
     rest_base_url="https://host:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    credentials=BasicAuth("user", "pass"),  # or LTPAAuth / CertificateAuth
+    credentials=LTPAAuth("user", "pass"),  # or CertificateAuth / BasicAuth
     map_attributes=True,      # snake_case <-> MQSC translation (default)
     mapping_strict=True,      # raise on unknown attributes (default)
     verify_tls=True,          # TLS certificate verification (default)
@@ -118,11 +118,11 @@ parameter access.
 
 Three credential types are supported:
 
-- `BasicAuth(username, password)` — HTTP Basic authentication
-- `LTPAAuth(username, password)` — LTPA token login (automatic at
-  session creation)
 - `CertificateAuth(cert_path, key_path)` — mutual TLS client
   certificates
+- `LTPAAuth(username, password)` — LTPA token login (automatic at
+  session creation)
+- `BasicAuth(username, password)` — HTTP Basic authentication
 
 ## Documentation
 

--- a/docs/announcements/pymqrest-1.0.0-ga.md
+++ b/docs/announcements/pymqrest-1.0.0-ga.md
@@ -22,12 +22,12 @@ mapping, and idempotent `ensure_*` methods for declarative object
 management.
 
 ```python
-from pymqrest import MQRESTSession, BasicAuth
+from pymqrest import MQRESTSession, LTPAAuth
 
 session = MQRESTSession(
     rest_base_url="https://mq-host:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    credentials=BasicAuth("admin", "admin"),
+    credentials=LTPAAuth("admin", "admin"),
 )
 
 # List local queues with Pythonic attribute names
@@ -53,8 +53,8 @@ Highlights:
   alter only what changed, skip when already correct
 - **No native dependencies** &mdash; pure Python over HTTPS, works
   anywhere `requests` runs
-- **Three auth modes**: HTTP Basic, LTPA token, and mutual TLS client
-  certificates
+- **Three auth modes**: mutual TLS client certificates, LTPA token,
+  and HTTP Basic
 - **100% test coverage**, strict mypy + ty typing, all ruff rules
   enabled
 
@@ -118,8 +118,8 @@ altering, and deleting MQ objects programmatically.
 - **Idempotent ensure methods**: declarative upsert for 16 object types
   (queues, channels, topics, listeners, and more) &mdash; define if
   missing, alter only changed attributes, no-op when already correct
-- **Flexible authentication**: HTTP Basic, LTPA token login, and mutual
-  TLS client certificates
+- **Flexible authentication**: mutual TLS client certificates, LTPA
+  token login, and HTTP Basic
 - **Diagnostic state**: session retains last command/response payloads
   and HTTP status for inspection
 - **Strict quality bar**: 100% branch coverage, strict mypy + ty

--- a/docs/sphinx/api/auth.md
+++ b/docs/sphinx/api/auth.md
@@ -5,7 +5,8 @@ authentication modes supported by the IBM MQ REST API: mutual TLS (mTLS)
 client certificates, LTPA token, and HTTP Basic.
 
 Pass a credential object to `MQRESTSession` via the `credentials`
-keyword argument.
+keyword argument. Always use TLS (`https://`) for production
+deployments to protect credentials and data in transit.
 
 ```python
 from pymqrest import MQRESTSession, BasicAuth, LTPAAuth, CertificateAuth
@@ -42,12 +43,13 @@ session = MQRESTSession("https://...", "QM1", credentials=BasicAuth("user", "pas
 Both LTPA and Basic authentication use a username and password. The key
 difference is how often those credentials cross the wire.
 
-**Prefer LTPA when possible.** Credentials are sent once during the
-`/login` request; subsequent API calls carry only the LTPA cookie. This
-reduces credential exposure and is more efficient for sessions that issue
-many commands.
+**LTPA is the recommended choice for username/password authentication.**
+Credentials are sent once during the `/login` request; subsequent API
+calls carry only the LTPA cookie. This reduces credential exposure and
+is more efficient for sessions that issue many commands. All examples
+and documentation in this project use LTPA as the default.
 
-**Basic authentication is appropriate when:**
+**Use Basic authentication as a fallback when:**
 
 - The mqweb configuration does not enable the `/login` endpoint (for
   example, minimal container images that only expose the REST API).

--- a/docs/sphinx/examples.md
+++ b/docs/sphinx/examples.md
@@ -103,13 +103,13 @@ to call the functions directly:
 
 ```python
 from pymqrest import MQRESTSession
-from pymqrest.auth import BasicAuth
+from pymqrest.auth import LTPAAuth
 from examples.health_check import check_health
 
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    credentials=BasicAuth("mqadmin", "mqadmin"),
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
     verify_tls=False,
 )
 

--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -21,12 +21,12 @@ REST API base URL, queue manager name, and credentials:
 
 ```python
 from pymqrest import MQRESTSession
-from pymqrest.auth import BasicAuth
+from pymqrest.auth import LTPAAuth
 
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    credentials=BasicAuth("mqadmin", "mqadmin"),
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
     verify_tls=False,  # for local development only
 )
 ```
@@ -80,7 +80,7 @@ Mapping can be disabled at the session level or per method call:
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    credentials=BasicAuth("mqadmin", "mqadmin"),
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
     map_attributes=False,
 )
 ```
@@ -98,7 +98,7 @@ unchanged:
 session = MQRESTSession(
     rest_base_url="https://localhost:9443/ibmmq/rest/v2",
     qmgr_name="QM1",
-    credentials=BasicAuth("mqadmin", "mqadmin"),
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
     mapping_strict=False,
 )
 ```

--- a/examples/channel_status.py
+++ b/examples/channel_status.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from os import getenv
 
 from pymqrest import MQRESTError, MQRESTSession
-from pymqrest.auth import BasicAuth
+from pymqrest.auth import LTPAAuth
 
 
 @dataclass
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
+        credentials=LTPAAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 

--- a/examples/dlq_inspector.py
+++ b/examples/dlq_inspector.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from os import getenv
 
 from pymqrest import MQRESTSession
-from pymqrest.auth import BasicAuth
+from pymqrest.auth import LTPAAuth
 
 CRITICAL_DEPTH_PCT = 90
 
@@ -147,7 +147,7 @@ if __name__ == "__main__":
     session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
+        credentials=LTPAAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 

--- a/examples/health_check.py
+++ b/examples/health_check.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from os import getenv
 
 from pymqrest import MQRESTError, MQRESTSession
-from pymqrest.auth import BasicAuth
+from pymqrest.auth import LTPAAuth
 
 
 @dataclass
@@ -122,7 +122,7 @@ if __name__ == "__main__":
         MQRESTSession(
             rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
             qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-            credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
+            credentials=LTPAAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
             verify_tls=False,
         )
     )
@@ -133,7 +133,7 @@ if __name__ == "__main__":
             MQRESTSession(
                 rest_base_url=qm2_url,
                 qmgr_name="QM2",
-                credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
+                credentials=LTPAAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
                 verify_tls=False,
             )
         )

--- a/examples/provision_environment.py
+++ b/examples/provision_environment.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from os import getenv
 
 from pymqrest import MQRESTError, MQRESTSession
-from pymqrest.auth import BasicAuth
+from pymqrest.auth import LTPAAuth
 
 PREFIX = "PROV"
 
@@ -289,14 +289,14 @@ if __name__ == "__main__":
     qm1_session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name="QM1",
-        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
+        credentials=LTPAAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 
     qm2_session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL_QM2", "https://localhost:9444/ibmmq/rest/v2"),
         qmgr_name="QM2",
-        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
+        credentials=LTPAAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 

--- a/examples/queue_depth_monitor.py
+++ b/examples/queue_depth_monitor.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from os import getenv
 
 from pymqrest import MQRESTSession
-from pymqrest.auth import BasicAuth
+from pymqrest.auth import LTPAAuth
 
 
 @dataclass
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     session = MQRESTSession(
         rest_base_url=getenv("MQ_REST_BASE_URL", "https://localhost:9443/ibmmq/rest/v2"),
         qmgr_name=getenv("MQ_QMGR_NAME", "QM1"),
-        credentials=BasicAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
+        credentials=LTPAAuth(getenv("MQ_ADMIN_USER", "mqadmin"), getenv("MQ_ADMIN_PASSWORD", "mqadmin")),
         verify_tls=False,
     )
 


### PR DESCRIPTION
## Summary

- Switch all example scripts and documentation code samples from `BasicAuth` to `LTPAAuth` as the recommended credential type for username/password scenarios
- Reorder authentication listings to `CertificateAuth` → `LTPAAuth` → `BasicAuth` (strongest to weakest) in README, announcement, and auth docs
- Strengthen LTPA guidance in `docs/sphinx/api/auth.md` and add TLS recommendation for production deployments
- Fix Python version requirement in README (`3.14+` → `3.12+`)

## Test plan

- [x] `uv run ruff check` — all rules pass
- [x] `uv run ruff format --check .` — no formatting issues
- [x] `uv run python3 scripts/dev/validate_local.py` — full validation suite passes (100% coverage)
- [x] `uv run python3 scripts/dev/validate_docs.py` — docs validation passes

Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)