### PR TITLE
feat: include changed attributes in EnsureResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ result = session.ensure_qlocal(
     name="APP.REQUESTS",
     request_parameters={"max_queue_depth": "50000"},
 )
-print(result)  # EnsureResult.CREATED, UPDATED, or UNCHANGED
+print(result.action)  # EnsureAction.CREATED, UPDATED, or UNCHANGED
 ```
 
 ## API overview
@@ -98,8 +98,9 @@ for 15 object types (queues, channels, topics, listeners, and more):
 - **ALTER** only the attributes that differ
 - **No-op** when all specified attributes already match
 
-Returns `EnsureResult.CREATED`, `EnsureResult.UPDATED`, or
-`EnsureResult.UNCHANGED`.
+Returns an `EnsureResult` whose `action` attribute is
+`EnsureAction.CREATED`, `UPDATED`, or `UNCHANGED`. When the action is
+`UPDATED`, `result.changed` contains the attribute names that differed.
 
 ### Attribute mapping
 

--- a/docs/announcements/pymqrest-1.0.0-ga.md
+++ b/docs/announcements/pymqrest-1.0.0-ga.md
@@ -39,7 +39,7 @@ result = session.ensure_qlocal(
     name="APP.REQUESTS",
     request_parameters={"max_queue_depth": "50000"},
 )
-print(result)  # EnsureResult.CREATED, UPDATED, or UNCHANGED
+print(result.action)  # EnsureAction.CREATED, UPDATED, or UNCHANGED
 ```
 
 Highlights:

--- a/docs/sphinx/api/ensure.md
+++ b/docs/sphinx/api/ensure.md
@@ -3,6 +3,15 @@
 The ensure module provides idempotent object management methods.
 See {doc}`/ensure-methods` for a conceptual overview and usage examples.
 
+## EnsureAction
+
+```{eval-rst}
+.. autoclass:: pymqrest.ensure.EnsureAction
+   :members:
+   :undoc-members:
+   :noindex:
+```
+
 ## EnsureResult
 
 ```{eval-rst}

--- a/src/pymqrest/__init__.py
+++ b/src/pymqrest/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import version
 
 from .auth import BasicAuth, CertificateAuth, Credentials, LTPAAuth
-from .ensure import EnsureResult
+from .ensure import EnsureAction, EnsureResult
 from .exceptions import (
     MQRESTAuthError,
     MQRESTCommandError,
@@ -26,6 +26,7 @@ __all__ = [
     "BasicAuth",
     "CertificateAuth",
     "Credentials",
+    "EnsureAction",
     "EnsureResult",
     "LTPAAuth",
     "MQRESTAuthError",

--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from pymqrest.auth import BasicAuth, LTPAAuth
-from pymqrest.ensure import EnsureResult
+from pymqrest.ensure import EnsureAction
 from pymqrest.exceptions import MQRESTError
 from pymqrest.session import MQRESTSession
 
@@ -419,11 +419,11 @@ def test_ensure_qmgr_lifecycle() -> None:
 
     # Alter to test value.
     result = session.ensure_qmgr(request_parameters={"description": test_descr})
-    assert result in {EnsureResult.UPDATED, EnsureResult.UNCHANGED}
+    assert result.action in {EnsureAction.UPDATED, EnsureAction.UNCHANGED}
 
     # Unchanged (same attributes).
     result = session.ensure_qmgr(request_parameters={"description": test_descr})
-    assert result is EnsureResult.UNCHANGED
+    assert result.action is EnsureAction.UNCHANGED
 
     # Restore original description.
     session.ensure_qmgr(request_parameters={"description": original_descr})
@@ -442,21 +442,21 @@ def test_ensure_qlocal_lifecycle() -> None:
         TEST_ENSURE_QLOCAL,
         request_parameters={"description": "ensure test"},
     )
-    assert result is EnsureResult.CREATED
+    assert result.action is EnsureAction.CREATED
 
     # Unchanged (same attributes).
     result = session.ensure_qlocal(
         TEST_ENSURE_QLOCAL,
         request_parameters={"description": "ensure test"},
     )
-    assert result is EnsureResult.UNCHANGED
+    assert result.action is EnsureAction.UNCHANGED
 
     # Updated (different attribute).
     result = session.ensure_qlocal(
         TEST_ENSURE_QLOCAL,
         request_parameters={"description": "ensure updated"},
     )
-    assert result is EnsureResult.UPDATED
+    assert result.action is EnsureAction.UPDATED
 
     # Cleanup.
     session.delete_queue(name=TEST_ENSURE_QLOCAL)
@@ -475,21 +475,21 @@ def test_ensure_channel_lifecycle() -> None:
         TEST_ENSURE_CHANNEL,
         request_parameters={"channel_type": "SVRCONN", "description": "ensure test"},
     )
-    assert result is EnsureResult.CREATED
+    assert result.action is EnsureAction.CREATED
 
     # Unchanged.
     result = session.ensure_channel(
         TEST_ENSURE_CHANNEL,
         request_parameters={"channel_type": "SVRCONN", "description": "ensure test"},
     )
-    assert result is EnsureResult.UNCHANGED
+    assert result.action is EnsureAction.UNCHANGED
 
     # Updated.
     result = session.ensure_channel(
         TEST_ENSURE_CHANNEL,
         request_parameters={"channel_type": "SVRCONN", "description": "ensure updated"},
     )
-    assert result is EnsureResult.UPDATED
+    assert result.action is EnsureAction.UPDATED
 
     # Cleanup.
     session.delete_channel(name=TEST_ENSURE_CHANNEL)


### PR DESCRIPTION
## Summary

- Restructure `EnsureResult` from an enum into a frozen dataclass with an `EnsureAction` enum for the action discriminant and a `changed: tuple[str, ...]` that surfaces which attributes triggered the ALTER command
- Export `EnsureAction` from `pymqrest.__init__`
- Update all tests, integration tests, and documentation (README, ensure-methods docs, API docs, announcement)

Fixes #178

## Test plan

- [x] `uv run ruff check && uv run ruff format --check .` — clean
- [x] `uv run pytest --cov=pymqrest --cov-report=term-missing --cov-branch --cov-fail-under=100` — 173 passed, 100% coverage
- [x] `uv run mypy src/ examples/` — no issues
- [x] `uv run ty check src` — all checks passed
- [x] `uv run python3 scripts/dev/validate_local.py` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)