### PR TITLE
fix: merge main back into develop in version bump PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,6 +168,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           git checkout -b "${{ steps.next_version.outputs.branch }}" origin/develop
+          git merge origin/main --no-edit
 
           python3 -c "
           from pathlib import Path
@@ -199,8 +200,10 @@ jobs:
             --body "$(cat <<'EOF'
           Automated patch version bump after publishing ${{ steps.version.outputs.version }}.
 
-          This sets the working version to the next expected patch release.
-          Change this to a minor or major bump if the next release warrants it.
+          This merges `main` back into `develop` to pick up the changelog and any
+          other release-branch artifacts, then sets the working version to the next
+          expected patch release. Change this to a minor or major bump if the next
+          release warrants it.
 
           Dependencies are refreshed to their latest compatible versions
           via `uv lock --upgrade`.


### PR DESCRIPTION
## Summary

- Add `git merge origin/main --no-edit` to the publish workflow's version-bump
  step so that CHANGELOG.md and other release-branch artifacts reach develop
- Update the PR body text to describe the merge-back behavior

## Test plan

- [ ] Review the workflow diff for correct placement of the merge step
- [ ] Verify next release cycle produces a bump PR that includes the changelog

Fixes #113

Generated with [Claude Code](https://claude.com/claude-code)