### PR TITLE
chore: merge main back into develop for 1.0.2 changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -208,6 +208,7 @@ jobs:
           Dependencies are refreshed to their latest compatible versions
           via `uv lock --upgrade`.
 
+
           Ref #113
           EOF
           )"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.2] - 2026-02-11
+
+### Bug fixes
+
+- use regular merge for release PRs and refresh deps in version bump (#172)
+
+### Documentation
+
+- add pymqrest 1.0.0 GA announcement draft (#176)
+- use LTPAAuth as default in examples and docs (#181)
+
+### Features
+
+- add Python 3.12 and 3.13 support (#180)
+- include changed attributes in EnsureResult (#178) (#182)
+
 ## [1.0.1] - 2026-02-10
 
 ### Bug fixes
 
 - resolve bare branch names to origin/ in commit-messages.sh (#159)
 - use full version in release branch name to avoid collisions (#161)
+- allow commits on release/* branches in pre-commit hook (#162)
+- merge main into release branch to reconcile squash-merge history (#164)
+- use conventional commit message for release merge commit (#165)
+- create release branch from main to avoid history pollution (#167)
+- generate changelog on develop before creating release branch (#169)
 
 ### Features
 

--- a/scripts/lint/commit-messages.sh
+++ b/scripts/lint/commit-messages.sh
@@ -19,9 +19,17 @@ fi
 
 conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
 
+# Commits at or before this SHA predate the conventional commits convention
+# and are excluded from validation.
+CUTOFF_SHA="479874c8779d058932928e2f6725b7a9eacefaa7"
+
 failed=0
 
 while IFS= read -r commit_sha; do
+  # Skip commits that predate the conventional commits convention.
+  if git merge-base --is-ancestor "$commit_sha" "$CUTOFF_SHA" 2>/dev/null; then
+    continue
+  fi
   subject_line="$(git log -n 1 --format=%s "$commit_sha")"
   if [[ ! "$subject_line" =~ $conventional_regex ]]; then
     echo "ERROR: commit $commit_sha does not follow Conventional Commits." >&2


### PR DESCRIPTION
## Summary

- One-time merge of `main` back into `develop` to bring over the 1.0.2
  changelog entries and additional 1.0.1 bug-fix entries that were never
  merged back after the release
- Future releases will handle this automatically via #186

## Test plan

- [ ] Verify CHANGELOG.md on develop includes the 1.0.2 section after merge

Ref #113

Generated with [Claude Code](https://claude.com/claude-code)