### PR TITLE
fix: use PAT and merge strategy for version bump PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,8 +165,10 @@ jobs:
       - name: Create version bump PR
         if: steps.bump_check.outputs.needed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_PR_BUMP_TOKEN }}
         run: |
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git checkout -b "${{ steps.next_version.outputs.branch }}" origin/develop
           git merge origin/main --no-edit
 
@@ -212,3 +214,7 @@ jobs:
           Ref #113
           EOF
           )"
+
+          gh pr merge \
+            --auto --merge --delete-branch \
+            "${{ steps.next_version.outputs.branch }}"


### PR DESCRIPTION
## Summary

- Switch bump PR step from `github.token` to `GITHUB_PR_BUMP_TOKEN` (PAT) so the push triggers CI and required status checks can pass
- Configure `git remote set-url` to authenticate pushes with the PAT
- Add `gh pr merge --auto --merge --delete-branch` so the bump PR auto-merges once checks pass
- Use `--merge` (not `--squash`) to preserve the `git merge origin/main` commit, maintaining shared ancestry between main and develop

## Context

The 1.0.3 release exposed two issues with the automated bump PR:

1. **CI never triggers** — `GITHUB_TOKEN` pushes don't trigger workflows by design, so required status checks never pass and auto-merge can't complete
2. **Squash merge breaks ancestry** — PR #189 was squash-merged, which destroyed the shared merge base from `git merge origin/main`, causing CHANGELOG conflicts on subsequent releases

## Prerequisites

Before this workflow change takes effect, a fine-grained PAT must be created and stored as the repo secret `GITHUB_PR_BUMP_TOKEN` with Contents (read/write) and Pull requests (read/write) permissions.

## Test plan

- [ ] Create `GITHUB_PR_BUMP_TOKEN` repo secret with appropriate PAT
- [ ] Reconciliation merge of `origin/main` into `develop` (separate PR, `--merge` not `--squash`)
- [ ] Next release validates end-to-end: bump PR triggers CI, auto-merges, preserves ancestry

Ref #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)