### PR TITLE
feat: add mapping_overrides parameter to MQRESTSession

### DIFF
--- a/src/pymqrest/_mapping_merge.py
+++ b/src/pymqrest/_mapping_merge.py
@@ -1,0 +1,154 @@
+"""Internal helpers for validating and merging mapping overrides."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import cast
+
+_VALID_TOP_LEVEL_KEYS = frozenset({"commands", "qualifiers"})
+
+_VALID_QUALIFIER_SUB_KEYS = frozenset(
+    {
+        "request_key_map",
+        "request_value_map",
+        "request_key_value_map",
+        "response_key_map",
+        "response_value_map",
+    }
+)
+
+
+def validate_mapping_overrides(overrides: Mapping[str, object]) -> None:
+    """Validate the structure of a mapping overrides dict.
+
+    Raises ``TypeError`` for type violations and ``ValueError`` for
+    invalid keys.
+    """
+    _validate_top_level_keys(overrides)
+    _validate_commands_section(overrides.get("commands"))
+    _validate_qualifiers_section(overrides.get("qualifiers"))
+
+
+def _validate_top_level_keys(overrides: Mapping[str, object]) -> None:
+    for key in overrides:
+        if key not in _VALID_TOP_LEVEL_KEYS:
+            msg = f"Invalid top-level key in mapping_overrides: {key!r} (expected subset of {sorted(_VALID_TOP_LEVEL_KEYS)})"
+            raise ValueError(msg)
+
+
+def _validate_commands_section(commands: object) -> None:
+    if commands is None:
+        return
+    if not isinstance(commands, Mapping):
+        msg = "mapping_overrides['commands'] must be a Mapping"
+        raise TypeError(msg)
+    commands_map = cast("Mapping[str, object]", commands)
+    for command_key, command_entry in commands_map.items():
+        if not isinstance(command_entry, Mapping):
+            msg = f"mapping_overrides['commands'][{command_key!r}] must be a Mapping"
+            raise TypeError(msg)
+
+
+def _validate_qualifiers_section(qualifiers: object) -> None:
+    if qualifiers is None:
+        return
+    if not isinstance(qualifiers, Mapping):
+        msg = "mapping_overrides['qualifiers'] must be a Mapping"
+        raise TypeError(msg)
+    qualifiers_map = cast("Mapping[str, object]", qualifiers)
+    for qualifier_key, qualifier_entry in qualifiers_map.items():
+        if not isinstance(qualifier_entry, Mapping):
+            msg = f"mapping_overrides['qualifiers'][{qualifier_key!r}] must be a Mapping"
+            raise TypeError(msg)
+        _validate_qualifier_entry(qualifier_key, cast("Mapping[str, object]", qualifier_entry))
+
+
+def _validate_qualifier_entry(qualifier_key: str, entry: Mapping[str, object]) -> None:
+    for sub_key in entry:
+        if sub_key not in _VALID_QUALIFIER_SUB_KEYS:
+            msg = (
+                f"Invalid sub-key {sub_key!r} in mapping_overrides['qualifiers'][{qualifier_key!r}] "
+                f"(expected subset of {sorted(_VALID_QUALIFIER_SUB_KEYS)})"
+            )
+            raise ValueError(msg)
+        sub_value = entry[sub_key]
+        if not isinstance(sub_value, Mapping):
+            msg = f"mapping_overrides['qualifiers'][{qualifier_key!r}][{sub_key!r}] must be a Mapping"
+            raise TypeError(msg)
+
+
+def merge_mapping_data(
+    base: dict[str, object],
+    overrides: Mapping[str, object],
+) -> dict[str, object]:
+    """Deep-copy *base* and merge *overrides* into it.
+
+    Commands: per-command shallow merge.
+    Qualifiers: per-qualifier, per-sub-map key-level merge.
+    """
+    merged = copy.deepcopy(base)
+    _merge_commands(merged, overrides.get("commands"))
+    _merge_qualifiers(merged, overrides.get("qualifiers"))
+    return merged
+
+
+def _merge_commands(merged: dict[str, object], override_commands: object) -> None:
+    if not isinstance(override_commands, Mapping):
+        return
+    base_commands_raw = merged.get("commands")
+    if not isinstance(base_commands_raw, dict):
+        base_commands_raw = {}
+        merged["commands"] = base_commands_raw
+    base_commands = cast("dict[str, object]", base_commands_raw)
+    commands_map = cast("Mapping[str, object]", override_commands)
+    for command_key, command_entry in commands_map.items():
+        if not isinstance(command_entry, Mapping):
+            continue
+        existing = base_commands.get(command_key)
+        if isinstance(existing, dict):
+            cast("dict[str, object]", existing).update(
+                cast("Mapping[str, object]", command_entry),
+            )
+        else:
+            base_commands[command_key] = dict(command_entry)
+
+
+def _merge_qualifiers(merged: dict[str, object], override_qualifiers: object) -> None:
+    if not isinstance(override_qualifiers, Mapping):
+        return
+    base_qualifiers_raw = merged.get("qualifiers")
+    if not isinstance(base_qualifiers_raw, dict):
+        base_qualifiers_raw = {}
+        merged["qualifiers"] = base_qualifiers_raw
+    base_qualifiers = cast("dict[str, object]", base_qualifiers_raw)
+    qualifiers_map = cast("Mapping[str, object]", override_qualifiers)
+    for qualifier_key, qualifier_entry in qualifiers_map.items():
+        if not isinstance(qualifier_entry, Mapping):
+            continue
+        _merge_single_qualifier(
+            base_qualifiers,
+            qualifier_key,
+            cast("Mapping[str, object]", qualifier_entry),
+        )
+
+
+def _merge_single_qualifier(
+    base_qualifiers: dict[str, object],
+    qualifier_key: str,
+    qualifier_entry: Mapping[str, object],
+) -> None:
+    existing_raw = base_qualifiers.get(qualifier_key)
+    if not isinstance(existing_raw, dict):
+        base_qualifiers[qualifier_key] = dict(qualifier_entry)
+        return
+    existing_qualifier = cast("dict[str, object]", existing_raw)
+    for sub_key, sub_value in qualifier_entry.items():
+        if isinstance(sub_value, Mapping):
+            existing_sub = existing_qualifier.get(sub_key)
+            if isinstance(existing_sub, dict):
+                cast("dict[str, object]", existing_sub).update(
+                    cast("Mapping[str, object]", sub_value),
+                )
+            else:
+                existing_qualifier[sub_key] = dict(sub_value)

--- a/src/pymqrest/mapping.py
+++ b/src/pymqrest/mapping.py
@@ -128,6 +128,7 @@ def map_request_attributes(
     attributes: Mapping[str, object],
     *,
     strict: bool = True,
+    mapping_data: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     """Map request attributes from ``snake_case`` into MQSC parameter names.
 
@@ -141,6 +142,9 @@ def map_request_attributes(
         strict: When ``True`` (default), raise :class:`MappingError`
             on any unrecognised key, value, or qualifier. When ``False``,
             pass unrecognised attributes through unchanged.
+        mapping_data: Optional mapping data to use instead of the
+            built-in :data:`MAPPING_DATA`. When ``None`` (default),
+            the module-level data is used.
 
     Returns:
         A new dict with MQSC parameter names as keys.
@@ -150,7 +154,7 @@ def map_request_attributes(
             be mapped.
 
     """
-    qualifier_data = _get_qualifier_data(qualifier)
+    qualifier_data = _get_qualifier_data(qualifier, mapping_data=mapping_data)
     if qualifier_data is None:
         return _handle_unknown_qualifier(
             qualifier,
@@ -174,6 +178,7 @@ def map_response_attributes(
     attributes: Mapping[str, object],
     *,
     strict: bool = True,
+    mapping_data: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     """Map response attributes from MQSC parameter names to ``snake_case``.
 
@@ -187,6 +192,9 @@ def map_response_attributes(
         strict: When ``True`` (default), raise :class:`MappingError`
             on any unrecognised key, value, or qualifier. When ``False``,
             pass unrecognised attributes through unchanged.
+        mapping_data: Optional mapping data to use instead of the
+            built-in :data:`MAPPING_DATA`. When ``None`` (default),
+            the module-level data is used.
 
     Returns:
         A new dict with ``snake_case`` attribute names as keys.
@@ -196,7 +204,7 @@ def map_response_attributes(
             be mapped.
 
     """
-    qualifier_data = _get_qualifier_data(qualifier)
+    qualifier_data = _get_qualifier_data(qualifier, mapping_data=mapping_data)
     if qualifier_data is None:
         return _handle_unknown_qualifier(
             qualifier,
@@ -220,6 +228,7 @@ def map_response_list(
     objects: Sequence[Mapping[str, object]],
     *,
     strict: bool = True,
+    mapping_data: Mapping[str, object] | None = None,
 ) -> list[dict[str, object]]:
     """Map a list of response objects from MQSC names to ``snake_case``.
 
@@ -235,6 +244,9 @@ def map_response_list(
         strict: When ``True`` (default), raise :class:`MappingError`
             if any attribute in any object cannot be mapped. When
             ``False``, pass unrecognised attributes through unchanged.
+        mapping_data: Optional mapping data to use instead of the
+            built-in :data:`MAPPING_DATA`. When ``None`` (default),
+            the module-level data is used.
 
     Returns:
         A list of dicts with ``snake_case`` attribute names.
@@ -245,7 +257,7 @@ def map_response_list(
             span multiple objects.
 
     """
-    qualifier_data = _get_qualifier_data(qualifier)
+    qualifier_data = _get_qualifier_data(qualifier, mapping_data=mapping_data)
     if qualifier_data is None:
         return _handle_unknown_qualifier_list(
             qualifier,
@@ -274,8 +286,13 @@ def map_response_list(
     return mapped_objects
 
 
-def _get_qualifier_data(qualifier: str) -> Mapping[str, object] | None:
-    qualifiers = MAPPING_DATA.get("qualifiers")
+def _get_qualifier_data(
+    qualifier: str,
+    *,
+    mapping_data: Mapping[str, object] | None = None,
+) -> Mapping[str, object] | None:
+    data = mapping_data if mapping_data is not None else MAPPING_DATA
+    qualifiers = data.get("qualifiers")
     if not isinstance(qualifiers, Mapping):
         return None
     qualifier_map = cast("Mapping[str, object]", qualifiers)

--- a/tests/pymqrest/test_mapping.py
+++ b/tests/pymqrest/test_mapping.py
@@ -302,6 +302,61 @@ def test_mapping_issue_serializes_nested_values() -> None:
     }
 
 
+def test_map_request_attributes_with_explicit_mapping_data() -> None:
+    custom_data: dict[str, object] = {
+        "qualifiers": {
+            "custom": {
+                "request_key_map": {"my_key": "MY_KEY"},
+                "request_value_map": {},
+            },
+        },
+    }
+
+    result = map_request_attributes("custom", {"my_key": "val"}, mapping_data=custom_data)
+
+    assert result == {"MY_KEY": "val"}
+
+
+def test_map_response_attributes_with_explicit_mapping_data() -> None:
+    custom_data: dict[str, object] = {
+        "qualifiers": {
+            "custom": {
+                "response_key_map": {"MY_KEY": "my_key"},
+                "response_value_map": {},
+            },
+        },
+    }
+
+    result = map_response_attributes("custom", {"MY_KEY": "val"}, mapping_data=custom_data)
+
+    assert result == {"my_key": "val"}
+
+
+def test_map_response_list_with_explicit_mapping_data() -> None:
+    custom_data: dict[str, object] = {
+        "qualifiers": {
+            "custom": {
+                "response_key_map": {"ATTR": "attr"},
+                "response_value_map": {},
+            },
+        },
+    }
+
+    result = map_response_list("custom", [{"ATTR": "val"}], mapping_data=custom_data)
+
+    assert result == [{"attr": "val"}]
+
+
+def test_mapping_data_none_uses_module_default() -> None:
+    result = map_request_attributes(
+        "queue",
+        {"default_persistence": "def"},
+        mapping_data=None,
+    )
+
+    assert result == {"DEFPSIST": "DEF"}
+
+
 def test_mapping_issue_serializes_none() -> None:
     issue = MappingIssue(
         direction="response",

--- a/tests/pymqrest/test_mapping_merge.py
+++ b/tests/pymqrest/test_mapping_merge.py
@@ -1,0 +1,220 @@
+"""Tests for the internal mapping merge module."""
+
+from __future__ import annotations
+
+import pytest
+
+from pymqrest._mapping_merge import merge_mapping_data, validate_mapping_overrides
+
+# -- validate_mapping_overrides --
+
+
+def test_validate_accepts_empty_overrides() -> None:
+    validate_mapping_overrides({})
+
+
+def test_validate_accepts_minimal_overrides() -> None:
+    validate_mapping_overrides({"commands": {}, "qualifiers": {}})
+
+
+def test_validate_rejects_invalid_top_level_key() -> None:
+    with pytest.raises(ValueError, match="Invalid top-level key"):
+        validate_mapping_overrides({"bogus": {}})
+
+
+def test_validate_rejects_non_mapping_commands() -> None:
+    with pytest.raises(TypeError, match=r"commands.*must be a Mapping"):
+        validate_mapping_overrides({"commands": "bad"})
+
+
+def test_validate_rejects_non_mapping_command_entry() -> None:
+    with pytest.raises(TypeError, match=r"commands.*must be a Mapping"):
+        validate_mapping_overrides({"commands": {"DISPLAY QUEUE": "bad"}})
+
+
+def test_validate_rejects_non_mapping_qualifiers() -> None:
+    with pytest.raises(TypeError, match=r"qualifiers.*must be a Mapping"):
+        validate_mapping_overrides({"qualifiers": "bad"})
+
+
+def test_validate_rejects_non_mapping_qualifier_entry() -> None:
+    with pytest.raises(TypeError, match=r"qualifiers.*must be a Mapping"):
+        validate_mapping_overrides({"qualifiers": {"queue": "bad"}})
+
+
+def test_validate_rejects_unknown_qualifier_sub_key() -> None:
+    with pytest.raises(ValueError, match="Invalid sub-key"):
+        validate_mapping_overrides({"qualifiers": {"queue": {"bogus_map": {}}}})
+
+
+def test_validate_rejects_non_mapping_sub_value() -> None:
+    with pytest.raises(TypeError, match="must be a Mapping"):
+        validate_mapping_overrides({"qualifiers": {"queue": {"request_key_map": "bad"}}})
+
+
+def test_validate_accepts_commands_with_valid_entries() -> None:
+    validate_mapping_overrides(
+        {
+            "commands": {"DISPLAY QUEUE": {"qualifier": "queue"}},
+        }
+    )
+
+
+def test_validate_accepts_all_valid_sub_keys() -> None:
+    validate_mapping_overrides(
+        {
+            "qualifiers": {
+                "queue": {
+                    "request_key_map": {},
+                    "request_value_map": {},
+                    "request_key_value_map": {},
+                    "response_key_map": {},
+                    "response_value_map": {},
+                },
+            },
+        }
+    )
+
+
+# -- merge_mapping_data --
+
+
+def test_merge_returns_deep_copy() -> None:
+    base: dict[str, object] = {
+        "commands": {"DISPLAY QUEUE": {"qualifier": "queue"}},
+        "qualifiers": {"queue": {"request_key_map": {"foo": "FOO"}}},
+    }
+    merged = merge_mapping_data(base, {})
+
+    assert merged == base
+    assert merged is not base
+    assert merged["commands"] is not base["commands"]
+
+
+def test_merge_does_not_mutate_base() -> None:
+    base: dict[str, object] = {
+        "commands": {"DISPLAY QUEUE": {"qualifier": "queue"}},
+        "qualifiers": {"queue": {"request_key_map": {"foo": "FOO"}}},
+    }
+    original_commands = dict(base["commands"])  # type: ignore[arg-type]
+
+    merge_mapping_data(base, {"commands": {"DISPLAY QUEUE": {"status": "override"}}})
+
+    assert base["commands"] == original_commands
+
+
+def test_merge_commands_shallow_merge() -> None:
+    base: dict[str, object] = {
+        "commands": {"DISPLAY QUEUE": {"qualifier": "queue", "status": "provisional"}},
+    }
+    overrides = {"commands": {"DISPLAY QUEUE": {"status": "override"}}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    cmd = merged["commands"]["DISPLAY QUEUE"]  # type: ignore[index]
+    assert cmd["qualifier"] == "queue"
+    assert cmd["status"] == "override"
+
+
+def test_merge_commands_adds_new_command() -> None:
+    base: dict[str, object] = {"commands": {"DISPLAY QUEUE": {"qualifier": "queue"}}}
+    overrides = {"commands": {"CUSTOM CMD": {"qualifier": "custom"}}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    assert "CUSTOM CMD" in merged["commands"]  # type: ignore[operator]
+    assert "DISPLAY QUEUE" in merged["commands"]  # type: ignore[operator]
+
+
+def test_merge_qualifiers_key_level_merge() -> None:
+    base: dict[str, object] = {
+        "qualifiers": {
+            "queue": {
+                "request_key_map": {"foo": "FOO", "bar": "BAR"},
+                "response_key_map": {"BSIZ": "buffer_size"},
+            },
+        },
+    }
+    overrides = {
+        "qualifiers": {
+            "queue": {
+                "request_key_map": {"foo": "OVERRIDDEN_FOO"},
+                "response_key_map": {"NEWATTR": "new_attribute"},
+            },
+        },
+    }
+
+    merged = merge_mapping_data(base, overrides)
+
+    qualifier = merged["qualifiers"]["queue"]  # type: ignore[index]
+    assert qualifier["request_key_map"]["foo"] == "OVERRIDDEN_FOO"
+    assert qualifier["request_key_map"]["bar"] == "BAR"
+    assert qualifier["response_key_map"]["BSIZ"] == "buffer_size"
+    assert qualifier["response_key_map"]["NEWATTR"] == "new_attribute"
+
+
+def test_merge_adds_new_qualifier() -> None:
+    base: dict[str, object] = {"qualifiers": {"queue": {"request_key_map": {"a": "A"}}}}
+    overrides = {"qualifiers": {"custom": {"request_key_map": {"x": "X"}}}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    assert "custom" in merged["qualifiers"]  # type: ignore[operator]
+    assert merged["qualifiers"]["custom"]["request_key_map"]["x"] == "X"  # type: ignore[index]
+    assert "queue" in merged["qualifiers"]  # type: ignore[operator]
+
+
+def test_merge_handles_missing_base_commands() -> None:
+    base: dict[str, object] = {"qualifiers": {}}
+    overrides = {"commands": {"NEW CMD": {"qualifier": "new"}}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    assert merged["commands"]["NEW CMD"]["qualifier"] == "new"  # type: ignore[index]
+
+
+def test_merge_handles_missing_base_qualifiers() -> None:
+    base: dict[str, object] = {"commands": {}}
+    overrides = {"qualifiers": {"new": {"request_key_map": {"a": "A"}}}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    assert merged["qualifiers"]["new"]["request_key_map"]["a"] == "A"  # type: ignore[index]
+
+
+def test_merge_skips_non_mapping_qualifier_entry() -> None:
+    base: dict[str, object] = {"qualifiers": {"queue": {"request_key_map": {"a": "A"}}}}
+    overrides: dict[str, object] = {"qualifiers": {"queue": "not_a_mapping"}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    assert merged["qualifiers"]["queue"]["request_key_map"]["a"] == "A"  # type: ignore[index]
+
+
+def test_merge_skips_non_mapping_sub_value() -> None:
+    base: dict[str, object] = {"qualifiers": {"queue": {"request_key_map": {"a": "A"}}}}
+    overrides: dict[str, object] = {"qualifiers": {"queue": {"request_key_map": "not_a_mapping"}}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    assert merged["qualifiers"]["queue"]["request_key_map"]["a"] == "A"  # type: ignore[index]
+
+
+def test_merge_skips_non_mapping_command_entry() -> None:
+    base: dict[str, object] = {"commands": {"DISPLAY QUEUE": {"qualifier": "queue"}}}
+    overrides: dict[str, object] = {"commands": {"DISPLAY QUEUE": "not_a_mapping"}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    assert merged["commands"]["DISPLAY QUEUE"]["qualifier"] == "queue"  # type: ignore[index]
+
+
+def test_merge_adds_new_sub_map_to_existing_qualifier() -> None:
+    base: dict[str, object] = {"qualifiers": {"queue": {"request_key_map": {"a": "A"}}}}
+    overrides = {"qualifiers": {"queue": {"response_key_map": {"B": "b_mapped"}}}}
+
+    merged = merge_mapping_data(base, overrides)
+
+    qualifier = merged["qualifiers"]["queue"]  # type: ignore[index]
+    assert qualifier["request_key_map"]["a"] == "A"
+    assert qualifier["response_key_map"]["B"] == "b_mapped"


### PR DESCRIPTION
## Summary

- Add `mapping_overrides` parameter to `MQRESTSession` so sites with existing naming conventions can layer sparse overrides on top of built-in `MAPPING_DATA` without forking
- New internal `_mapping_merge` module handles validation (at construction time) and deep-copy + key-level merge of override data
- Thread `mapping_data` through session helpers and `mapping.py` public functions so overrides apply to all mapping operations (request keys, response keys, values, WHERE keywords)
- Document the feature with examples in both `getting-started.md` and `mapping-pipeline.md`

## Test plan

- [ ] 23 new tests in `test_mapping_merge.py` cover validation and merge logic in isolation
- [ ] 6 new tests in `test_session.py` verify overrides through the full `_mqsc_command` flow (response key, request key, WHERE keyword, invalid overrides, defaults)
- [ ] 4 new tests in `test_mapping.py` verify explicit `mapping_data` parameter threading
- [ ] 100% branch coverage maintained (206 tests pass)
- [ ] Full `validate_local.py` passes (ruff, mypy, ty, pytest, docs)

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)