### PR TITLE
docs: correct platform availability claim in gateway docs

### DIFF
--- a/docs/sphinx/getting-started.md
+++ b/docs/sphinx/getting-started.md
@@ -172,9 +172,13 @@ construction time, so errors are caught early.
 
 ## Gateway queue manager
 
-In enterprise environments, queue managers often run on platforms where the
-MQ REST API is not available (AIX, z/OS, Windows). A **gateway queue manager**
-on Linux can route MQSC commands to remote queue managers via MQ channels.
+The MQ REST API is available on all supported IBM MQ platforms (Linux, AIX,
+Windows, z/OS, and IBM i). pymqrest is developed and tested against the
+**Linux** implementation only.
+
+In enterprise environments, a **gateway queue manager** can route MQSC
+commands to remote queue managers via MQ channels — the same mechanism used
+by `runmqsc -w` and the MQ Console.
 
 To use a gateway, pass `gateway_qmgr` when creating the session. The
 `qmgr_name` parameter specifies the **target** (remote) queue manager, while


### PR DESCRIPTION
## Summary

- Corrected the gateway queue manager section in `getting-started.md` which incorrectly stated that the MQ REST API is not available on AIX, z/OS, and Windows
- Listed all supported platforms (Linux, AIX, Windows, z/OS, and IBM i)
- Noted that pymqrest is developed and tested against the Linux implementation only
- Reframed the gateway description as a routing convenience rather than a platform workaround

Fixes #196

## Test plan

- [x] Docs-only change — `validate_docs.py` passes
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)