### PR TITLE
chore: remove legacy root standards-and-conventions.md shim

### DIFF
--- a/standards-and-conventions.md
+++ b/standards-and-conventions.md
@@ -1,7 +1,0 @@
-# pymqrest Standards Bootstrap
-
-## Table of Contents
-- [Includes](#includes)
-
-## Includes
-<!-- include: docs/standards-and-conventions.md -->


### PR DESCRIPTION
## Summary
- Delete the root `standards-and-conventions.md` file, which was a legacy indirection shim containing only a single include directive to `docs/standards-and-conventions.md`
- Both `CLAUDE.md` and `AGENTS.md` already include the `docs/` file directly — no references to the root file exist

Fixes #198

## Test plan
- [x] `validate_local.py` passes (all checks green)
- [x] Verified no other files reference the root-level `standards-and-conventions.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)