### PR TITLE
feat: add MappingOverrideMode.REPLACE for complete mapping replacement

### DIFF
--- a/src/pymqrest/__init__.py
+++ b/src/pymqrest/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import version
 
+from ._mapping_merge import MappingOverrideMode
 from .auth import BasicAuth, CertificateAuth, Credentials, LTPAAuth
 from .ensure import EnsureAction, EnsureResult
 from .exceptions import (
@@ -37,6 +38,7 @@ __all__ = [
     "MQRESTTransportError",
     "MappingError",
     "MappingIssue",
+    "MappingOverrideMode",
     "__version__",
     "map_request_attributes",
     "map_response_attributes",


### PR DESCRIPTION
## Summary

- Add `MappingOverrideMode` enum (`MERGE`/`REPLACE`) to `_mapping_merge.py`, following the `EnsureAction` pattern
- Add `mapping_overrides_mode` parameter to `MQRESTSession.__init__` — `REPLACE` mode validates completeness at command and qualifier key levels, then deep-copies overrides as the sole mapping data
- Export `MappingOverrideMode` from `pymqrest.__init__`
- Add 16 new tests (12 in `test_mapping_merge.py`, 4 in `test_session.py`) — 100% branch coverage maintained

Ref #194

## Test plan

- [x] `uv run pytest --cov=pymqrest --cov-report=term-missing --cov-branch --cov-fail-under=100` — 227 passed, 100% coverage
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check .` — all files formatted
- [x] `uv run mypy src/` — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)