### PR TITLE
feat: add synchronous start/stop/restart wrappers

### DIFF
--- a/docs/sphinx/api/exceptions.md
+++ b/docs/sphinx/api/exceptions.md
@@ -8,7 +8,8 @@ Exception
     ├── MQRESTAuthError        — authentication failures
     ├── MQRESTTransportError   — network/connection failures
     ├── MQRESTResponseError    — malformed responses
-    └── MQRESTCommandError     — MQSC command failures
+    ├── MQRESTCommandError     — MQSC command failures
+    └── MQRESTTimeoutError     — sync operation timeouts
 ```
 
 ```{eval-rst}
@@ -36,6 +37,12 @@ Exception
 
 ```{eval-rst}
 .. autoclass:: pymqrest.exceptions.MQRESTCommandError
+   :members:
+   :show-inheritance:
+```
+
+```{eval-rst}
+.. autoclass:: pymqrest.exceptions.MQRESTTimeoutError
    :members:
    :show-inheritance:
 ```

--- a/docs/sphinx/api/index.md
+++ b/docs/sphinx/api/index.md
@@ -7,6 +7,7 @@ session
 auth
 commands
 ensure
+sync
 mapping
 exceptions
 ```

--- a/docs/sphinx/api/sync.md
+++ b/docs/sphinx/api/sync.md
@@ -1,0 +1,40 @@
+# Sync methods
+
+The sync module provides synchronous start/stop/restart wrappers.
+See {doc}`/sync-methods` for a conceptual overview and usage examples.
+
+## SyncConfig
+
+```{eval-rst}
+.. autoclass:: pymqrest.sync.SyncConfig
+   :members:
+   :undoc-members:
+   :noindex:
+```
+
+## SyncOperation
+
+```{eval-rst}
+.. autoclass:: pymqrest.sync.SyncOperation
+   :members:
+   :undoc-members:
+   :noindex:
+```
+
+## SyncResult
+
+```{eval-rst}
+.. autoclass:: pymqrest.sync.SyncResult
+   :members:
+   :undoc-members:
+   :noindex:
+```
+
+## MQRESTSyncMixin
+
+```{eval-rst}
+.. autoclass:: pymqrest.sync.MQRESTSyncMixin
+   :members:
+   :show-inheritance:
+   :exclude-members: _mqsc_command
+```

--- a/docs/sphinx/index.md
+++ b/docs/sphinx/index.md
@@ -14,6 +14,7 @@ and error propagation.
 
 getting-started
 ensure-methods
+sync-methods
 examples
 architecture
 mapping-pipeline

--- a/docs/sphinx/sync-methods.md
+++ b/docs/sphinx/sync-methods.md
@@ -1,0 +1,218 @@
+# Synchronous start/stop/restart
+
+## The problem with fire-and-forget
+
+All MQSC `START` and `STOP` commands are fire-and-forget — they return
+immediately without waiting for the object to reach its target state.
+In practice, tooling that provisions infrastructure needs to wait until
+a channel is `RUNNING` or a listener is `STOPPED` before proceeding to
+the next step. Writing polling loops by hand is error-prone and
+clutters business logic with retry mechanics.
+
+## The sync pattern
+
+The `*_sync` and `restart_*` methods wrap the fire-and-forget commands
+with a polling loop that issues `DISPLAY *STATUS` until the object
+reaches a stable state or the timeout expires.
+
+Each call returns a `SyncResult` describing what happened:
+
+```python
+from pymqrest import SyncConfig, SyncOperation, SyncResult
+
+class SyncOperation(enum.Enum):
+    STARTED = "started"      # Object confirmed running
+    STOPPED = "stopped"      # Object confirmed stopped
+    RESTARTED = "restarted"  # Stop-then-start completed
+
+@dataclass(frozen=True)
+class SyncResult:
+    operation: SyncOperation
+    polls: int                # Number of status polls issued
+    elapsed_seconds: float    # Wall-clock time from command to confirmation
+```
+
+Polling is controlled by a `SyncConfig` dataclass:
+
+```python
+@dataclass(frozen=True)
+class SyncConfig:
+    timeout_seconds: float = 30.0      # Max wait before raising
+    poll_interval_seconds: float = 1.0  # Seconds between polls
+```
+
+If the object does not reach the target state within the timeout,
+`MQRESTTimeoutError` is raised.
+
+## Basic usage
+
+```python
+from pymqrest import MQRESTSession, SyncConfig, SyncOperation
+from pymqrest.auth import BasicAuth
+
+session = MQRESTSession(
+    rest_base_url="https://localhost:9443/ibmmq/rest/v2",
+    qmgr_name="QM1",
+    credentials=BasicAuth("mqadmin", "mqadmin"),
+    verify_tls=False,
+)
+
+# Start a channel and wait until it is RUNNING
+result = session.start_channel_sync("TO.PARTNER")
+assert result.operation is SyncOperation.STARTED
+print(f"Channel running after {result.polls} poll(s), {result.elapsed_seconds:.1f}s")
+
+# Stop a listener and wait until it is STOPPED
+result = session.stop_listener_sync("TCP.LISTENER")
+assert result.operation is SyncOperation.STOPPED
+```
+
+## Restart convenience
+
+The `restart_*` methods perform a synchronous stop followed by a
+synchronous start. Each phase gets the full timeout independently —
+worst case is 2x the configured timeout.
+
+The returned `SyncResult` reports **total** polls and **total** elapsed
+time across both phases:
+
+```python
+result = session.restart_channel("TO.PARTNER")
+assert result.operation is SyncOperation.RESTARTED
+print(f"Restarted in {result.elapsed_seconds:.1f}s ({result.polls} total polls)")
+```
+
+## Custom timeout and poll interval
+
+Pass a `SyncConfig` to override the defaults:
+
+```python
+from pymqrest import SyncConfig
+
+# Aggressive polling for fast local development
+fast = SyncConfig(timeout_seconds=10.0, poll_interval_seconds=0.25)
+result = session.start_service_sync("MY.SVC", config=fast)
+
+# Patient polling for remote queue managers
+patient = SyncConfig(timeout_seconds=120.0, poll_interval_seconds=5.0)
+result = session.start_channel_sync("REMOTE.CHL", config=patient)
+```
+
+## Timeout handling
+
+When the timeout expires, `MQRESTTimeoutError` is raised with
+diagnostic attributes:
+
+```python
+from pymqrest import MQRESTTimeoutError, SyncConfig
+
+try:
+    session.start_channel_sync(
+        "BROKEN.CHL",
+        config=SyncConfig(timeout_seconds=15.0),
+    )
+except MQRESTTimeoutError as err:
+    print(f"Object: {err.name}")       # "BROKEN.CHL"
+    print(f"Operation: {err.operation}")  # "start"
+    print(f"Elapsed: {err.elapsed:.1f}s")  # 15.0
+```
+
+`MQRESTTimeoutError` inherits from `MQRESTError`, so existing
+`except MQRESTError` handlers will catch it.
+
+## Available methods
+
+| Method | Operation | START/STOP qualifier | Status qualifier |
+| --- | --- | --- | --- |
+| `start_channel_sync()` | Start | `CHANNEL` | `CHSTATUS` |
+| `stop_channel_sync()` | Stop | `CHANNEL` | `CHSTATUS` |
+| `restart_channel()` | Restart | `CHANNEL` | `CHSTATUS` |
+| `start_listener_sync()` | Start | `LISTENER` | `LSSTATUS` |
+| `stop_listener_sync()` | Stop | `LISTENER` | `LSSTATUS` |
+| `restart_listener()` | Restart | `LISTENER` | `LSSTATUS` |
+| `start_service_sync()` | Start | `SERVICE` | `SVSTATUS` |
+| `stop_service_sync()` | Stop | `SERVICE` | `SVSTATUS` |
+| `restart_service()` | Restart | `SERVICE` | `SVSTATUS` |
+
+All methods share the same signature:
+
+```python
+def start_channel_sync(
+    self,
+    name: str,
+    *,
+    config: SyncConfig | None = None,
+) -> SyncResult:
+```
+
+The `config` parameter is keyword-only for API clarity.
+
+## Status detection
+
+The polling loop checks the `STATUS` attribute in the `DISPLAY *STATUS`
+response. The target values are:
+
+- **Start**: `RUNNING`
+- **Stop**: `STOPPED`
+
+### Channel stop edge case
+
+When a channel stops, its `CHSTATUS` record may disappear entirely
+(the `DISPLAY CHSTATUS` response returns no rows). The channel sync
+methods treat an empty status result as successfully stopped. Listener
+and service status records are always present, so empty results are not
+treated as stopped for those object types.
+
+## Attribute mapping
+
+The sync methods call `_mqsc_command` internally, so they participate
+in the same {doc}`mapping pipeline </mapping-pipeline>` as all other
+command methods. The status key is checked using both the mapped
+`snake_case` name and the raw MQSC name, so polling works correctly
+regardless of whether mapping is enabled or disabled.
+
+## Provisioning example
+
+The sync methods pair naturally with the
+{doc}`ensure methods </ensure-methods>` for end-to-end provisioning:
+
+```python
+from pymqrest import SyncConfig
+
+config = SyncConfig(timeout_seconds=60.0)
+
+# Ensure objects exist
+session.ensure_listener("TCP.LISTENER", request_parameters={
+    "transport_type": "TCP",
+    "port": 1415,
+    "start_mode": "MQSVC_CONTROL_Q_MGR",
+})
+session.ensure_channel("PARTNER.SVRCONN", request_parameters={
+    "channel_type": "SVRCONN",
+    "description": "Partner application channel",
+})
+
+# Start them synchronously
+session.start_listener_sync("TCP.LISTENER", config=config)
+session.start_channel_sync("PARTNER.SVRCONN", config=config)
+
+print("Infrastructure ready")
+```
+
+## Rolling restart example
+
+Restart all server-connection channels with error handling:
+
+```python
+from pymqrest import MQRESTTimeoutError, SyncConfig
+
+channels = ["APP.SVRCONN", "ADMIN.SVRCONN", "PARTNER.SVRCONN"]
+config = SyncConfig(timeout_seconds=30.0, poll_interval_seconds=2.0)
+
+for name in channels:
+    try:
+        result = session.restart_channel(name, config=config)
+        print(f"{name}: restarted in {result.elapsed_seconds:.1f}s")
+    except MQRESTTimeoutError as err:
+        print(f"{name}: timed out after {err.elapsed:.1f}s")
+```

--- a/src/pymqrest/__init__.py
+++ b/src/pymqrest/__init__.py
@@ -10,6 +10,7 @@ from .exceptions import (
     MQRESTCommandError,
     MQRESTError,
     MQRESTResponseError,
+    MQRESTTimeoutError,
     MQRESTTransportError,
 )
 from .mapping import (
@@ -20,6 +21,7 @@ from .mapping import (
     map_response_list,
 )
 from .session import MQRESTSession
+from .sync import SyncConfig, SyncOperation, SyncResult
 
 __version__ = version("pymqrest")
 
@@ -35,10 +37,14 @@ __all__ = [
     "MQRESTError",
     "MQRESTResponseError",
     "MQRESTSession",
+    "MQRESTTimeoutError",
     "MQRESTTransportError",
     "MappingError",
     "MappingIssue",
     "MappingOverrideMode",
+    "SyncConfig",
+    "SyncOperation",
+    "SyncResult",
     "__version__",
     "map_request_attributes",
     "map_response_attributes",

--- a/src/pymqrest/exceptions.py
+++ b/src/pymqrest/exceptions.py
@@ -121,3 +121,33 @@ class MQRESTCommandError(MQRESTError):
         super().__init__(message)
         self.payload = dict(payload)
         self.status_code = status_code
+
+
+class MQRESTTimeoutError(MQRESTError):
+    """Raised when a synchronous operation exceeds its timeout.
+
+    This indicates that a start, stop, or restart operation did not
+    reach the expected state within the configured timeout period.
+
+    Attributes:
+        name: The MQ object name that timed out.
+        operation: A description of the operation that timed out
+            (e.g. ``"start"``, ``"stop"``).
+        elapsed: The elapsed wall-clock seconds before the timeout.
+
+    """
+
+    def __init__(self, message: str, *, name: str, operation: str, elapsed: float) -> None:
+        """Initialize with object name, operation, and elapsed time.
+
+        Args:
+            message: Human-readable error description.
+            name: The MQ object name.
+            operation: The operation that timed out.
+            elapsed: Seconds elapsed before the timeout was raised.
+
+        """
+        super().__init__(message)
+        self.name = name
+        self.operation = operation
+        self.elapsed = elapsed

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -28,6 +28,7 @@ from .exceptions import (
 )
 from .mapping import MappingError, MappingIssue, map_request_attributes, map_response_list
 from .mapping_data import MAPPING_DATA
+from .sync import MQRESTSyncMixin
 
 DEFAULT_RESPONSE_PARAMETERS: list[str] = ["all"]
 DEFAULT_CSRF_TOKEN = "local"  # noqa: S105
@@ -165,7 +166,7 @@ class RequestsTransport:
         )
 
 
-class MQRESTSession(MQRESTEnsureMixin, MQRESTCommandMixin):
+class MQRESTSession(MQRESTSyncMixin, MQRESTEnsureMixin, MQRESTCommandMixin):
     """Session wrapper for MQ REST admin calls.
 
     Provides MQSC command execution via the IBM MQ ``runCommandJSON``

--- a/src/pymqrest/sync.py
+++ b/src/pymqrest/sync.py
@@ -1,0 +1,453 @@
+"""Synchronous start/stop/restart wrappers for MQ objects."""
+
+from __future__ import annotations
+
+import enum
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .exceptions import MQRESTTimeoutError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class SyncConfig:
+    """Configuration for synchronous polling operations.
+
+    Attributes:
+        timeout_seconds: Maximum wall-clock seconds to wait for the
+            object to reach the target state.
+        poll_interval_seconds: Seconds to sleep between status polls.
+
+    """
+
+    timeout_seconds: float = 30.0
+    poll_interval_seconds: float = 1.0
+
+
+class SyncOperation(enum.Enum):
+    """Operation performed by a synchronous wrapper.
+
+    Attributes:
+        STARTED: The object was started and confirmed running.
+        STOPPED: The object was stopped and confirmed stopped.
+        RESTARTED: The object was stopped then started.
+
+    """
+
+    STARTED = "started"
+    STOPPED = "stopped"
+    RESTARTED = "restarted"
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """Result of a synchronous start/stop/restart operation.
+
+    Attributes:
+        operation: The :class:`SyncOperation` that was performed.
+        polls: Total number of status polls issued.
+        elapsed_seconds: Total wall-clock seconds from command to
+            target state confirmation.
+
+    """
+
+    operation: SyncOperation
+    polls: int
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True)
+class _ObjectTypeConfig:
+    """Per-object-type metadata for polling logic."""
+
+    start_qualifier: str
+    stop_qualifier: str
+    status_qualifier: str
+    status_keys: tuple[str, ...]
+    empty_means_stopped: bool
+
+
+_CHANNEL_CONFIG = _ObjectTypeConfig(
+    start_qualifier="CHANNEL",
+    stop_qualifier="CHANNEL",
+    status_qualifier="CHSTATUS",
+    status_keys=("channel_status", "STATUS"),
+    empty_means_stopped=True,
+)
+
+_LISTENER_CONFIG = _ObjectTypeConfig(
+    start_qualifier="LISTENER",
+    stop_qualifier="LISTENER",
+    status_qualifier="LSSTATUS",
+    status_keys=("status", "STATUS"),
+    empty_means_stopped=False,
+)
+
+_SERVICE_CONFIG = _ObjectTypeConfig(
+    start_qualifier="SERVICE",
+    stop_qualifier="SERVICE",
+    status_qualifier="SVSTATUS",
+    status_keys=("status", "STATUS"),
+    empty_means_stopped=False,
+)
+
+_RUNNING_VALUES = frozenset({"RUNNING", "running"})
+_STOPPED_VALUES = frozenset({"STOPPED", "stopped"})
+
+
+class MQRESTSyncMixin:
+    """Mixin providing synchronous start/stop/restart wrappers.
+
+    Each ``*_sync`` method issues the MQSC command then polls the
+    corresponding ``DISPLAY *STATUS`` until the object reaches a
+    stable state or the timeout expires.  ``restart_*`` methods
+    perform a synchronous stop followed by a synchronous start.
+    """
+
+    def _mqsc_command(  # noqa: PLR0913
+        self,
+        *,
+        command: str,
+        mqsc_qualifier: str,
+        name: str | None,
+        request_parameters: Mapping[str, object] | None,
+        response_parameters: Sequence[str] | None,
+        where: str | None = None,
+    ) -> list[dict[str, object]]:
+        raise NotImplementedError  # pragma: no cover
+
+    # ------------------------------------------------------------------
+    # Channel
+    # ------------------------------------------------------------------
+
+    def start_channel_sync(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Start a channel and wait until it is running.
+
+        Args:
+            name: Channel name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with operation details.
+
+        Raises:
+            MQRESTTimeoutError: If the channel does not reach RUNNING
+                within the timeout.
+
+        """
+        return self._start_and_poll(name, _CHANNEL_CONFIG, config)
+
+    def stop_channel_sync(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Stop a channel and wait until it is stopped.
+
+        Args:
+            name: Channel name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with operation details.
+
+        Raises:
+            MQRESTTimeoutError: If the channel does not reach STOPPED
+                within the timeout.
+
+        """
+        return self._stop_and_poll(name, _CHANNEL_CONFIG, config)
+
+    def restart_channel(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Stop then start a channel, waiting for each phase.
+
+        Each phase gets the full timeout independently.
+
+        Args:
+            name: Channel name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with total polls and elapsed time
+            across both phases.
+
+        Raises:
+            MQRESTTimeoutError: If either phase exceeds the timeout.
+
+        """
+        return self._restart(name, _CHANNEL_CONFIG, config)
+
+    # ------------------------------------------------------------------
+    # Listener
+    # ------------------------------------------------------------------
+
+    def start_listener_sync(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Start a listener and wait until it is running.
+
+        Args:
+            name: Listener name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with operation details.
+
+        Raises:
+            MQRESTTimeoutError: If the listener does not reach RUNNING
+                within the timeout.
+
+        """
+        return self._start_and_poll(name, _LISTENER_CONFIG, config)
+
+    def stop_listener_sync(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Stop a listener and wait until it is stopped.
+
+        Args:
+            name: Listener name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with operation details.
+
+        Raises:
+            MQRESTTimeoutError: If the listener does not reach STOPPED
+                within the timeout.
+
+        """
+        return self._stop_and_poll(name, _LISTENER_CONFIG, config)
+
+    def restart_listener(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Stop then start a listener, waiting for each phase.
+
+        Each phase gets the full timeout independently.
+
+        Args:
+            name: Listener name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with total polls and elapsed time
+            across both phases.
+
+        Raises:
+            MQRESTTimeoutError: If either phase exceeds the timeout.
+
+        """
+        return self._restart(name, _LISTENER_CONFIG, config)
+
+    # ------------------------------------------------------------------
+    # Service
+    # ------------------------------------------------------------------
+
+    def start_service_sync(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Start a service and wait until it is running.
+
+        Args:
+            name: Service name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with operation details.
+
+        Raises:
+            MQRESTTimeoutError: If the service does not reach RUNNING
+                within the timeout.
+
+        """
+        return self._start_and_poll(name, _SERVICE_CONFIG, config)
+
+    def stop_service_sync(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Stop a service and wait until it is stopped.
+
+        Args:
+            name: Service name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with operation details.
+
+        Raises:
+            MQRESTTimeoutError: If the service does not reach STOPPED
+                within the timeout.
+
+        """
+        return self._stop_and_poll(name, _SERVICE_CONFIG, config)
+
+    def restart_service(
+        self,
+        name: str,
+        *,
+        config: SyncConfig | None = None,
+    ) -> SyncResult:
+        """Stop then start a service, waiting for each phase.
+
+        Each phase gets the full timeout independently.
+
+        Args:
+            name: Service name.
+            config: Optional polling configuration.
+
+        Returns:
+            A :class:`SyncResult` with total polls and elapsed time
+            across both phases.
+
+        Raises:
+            MQRESTTimeoutError: If either phase exceeds the timeout.
+
+        """
+        return self._restart(name, _SERVICE_CONFIG, config)
+
+    # ------------------------------------------------------------------
+    # Core polling helpers
+    # ------------------------------------------------------------------
+
+    def _start_and_poll(
+        self,
+        name: str,
+        obj_config: _ObjectTypeConfig,
+        config: SyncConfig | None,
+    ) -> SyncResult:
+        """Issue START then poll until the object is RUNNING."""
+        cfg = config or SyncConfig()
+        self._mqsc_command(
+            command="START",
+            mqsc_qualifier=obj_config.start_qualifier,
+            name=name,
+            request_parameters=None,
+            response_parameters=None,
+        )
+        polls = 0
+        start_time = time.monotonic()
+        while True:
+            time.sleep(cfg.poll_interval_seconds)
+            status_rows = self._mqsc_command(
+                command="DISPLAY",
+                mqsc_qualifier=obj_config.status_qualifier,
+                name=name,
+                request_parameters=None,
+                response_parameters=["all"],
+            )
+            polls += 1
+            if _has_status(status_rows, obj_config.status_keys, _RUNNING_VALUES):
+                elapsed = time.monotonic() - start_time
+                return SyncResult(SyncOperation.STARTED, polls=polls, elapsed_seconds=elapsed)
+            elapsed = time.monotonic() - start_time
+            if elapsed >= cfg.timeout_seconds:
+                msg = f"{obj_config.start_qualifier} '{name}' did not reach RUNNING within {cfg.timeout_seconds}s"
+                raise MQRESTTimeoutError(
+                    msg,
+                    name=name,
+                    operation="start",
+                    elapsed=elapsed,
+                )
+
+    def _stop_and_poll(
+        self,
+        name: str,
+        obj_config: _ObjectTypeConfig,
+        config: SyncConfig | None,
+    ) -> SyncResult:
+        """Issue STOP then poll until the object is STOPPED."""
+        cfg = config or SyncConfig()
+        self._mqsc_command(
+            command="STOP",
+            mqsc_qualifier=obj_config.stop_qualifier,
+            name=name,
+            request_parameters=None,
+            response_parameters=None,
+        )
+        polls = 0
+        start_time = time.monotonic()
+        while True:
+            time.sleep(cfg.poll_interval_seconds)
+            status_rows = self._mqsc_command(
+                command="DISPLAY",
+                mqsc_qualifier=obj_config.status_qualifier,
+                name=name,
+                request_parameters=None,
+                response_parameters=["all"],
+            )
+            polls += 1
+            if obj_config.empty_means_stopped and not status_rows:
+                elapsed = time.monotonic() - start_time
+                return SyncResult(SyncOperation.STOPPED, polls=polls, elapsed_seconds=elapsed)
+            if _has_status(status_rows, obj_config.status_keys, _STOPPED_VALUES):
+                elapsed = time.monotonic() - start_time
+                return SyncResult(SyncOperation.STOPPED, polls=polls, elapsed_seconds=elapsed)
+            elapsed = time.monotonic() - start_time
+            if elapsed >= cfg.timeout_seconds:
+                msg = f"{obj_config.stop_qualifier} '{name}' did not reach STOPPED within {cfg.timeout_seconds}s"
+                raise MQRESTTimeoutError(
+                    msg,
+                    name=name,
+                    operation="stop",
+                    elapsed=elapsed,
+                )
+
+    def _restart(
+        self,
+        name: str,
+        obj_config: _ObjectTypeConfig,
+        config: SyncConfig | None,
+    ) -> SyncResult:
+        """Stop-sync then start-sync, returning combined totals."""
+        stop_result = self._stop_and_poll(name, obj_config, config)
+        start_result = self._start_and_poll(name, obj_config, config)
+        return SyncResult(
+            SyncOperation.RESTARTED,
+            polls=stop_result.polls + start_result.polls,
+            elapsed_seconds=stop_result.elapsed_seconds + start_result.elapsed_seconds,
+        )
+
+
+def _has_status(
+    rows: list[dict[str, object]],
+    status_keys: tuple[str, ...],
+    target_values: frozenset[str],
+) -> bool:
+    """Check whether any row has a status value in the target set."""
+    for row in rows:
+        for key in status_keys:
+            value = row.get(key)
+            if isinstance(value, str) and value in target_values:
+                return True
+    return False

--- a/tests/pymqrest/test_sync.py
+++ b/tests/pymqrest/test_sync.py
@@ -1,0 +1,585 @@
+"""Tests for synchronous start/stop/restart wrappers."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pymqrest.auth import BasicAuth
+from pymqrest.exceptions import MQRESTError, MQRESTTimeoutError
+from pymqrest.session import MQRESTSession, TransportResponse
+from pymqrest.sync import SyncConfig, SyncOperation, SyncResult
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+TEST_PASSWORD = "pass"
+EXPECT_ONE_POLL = 1
+EXPECT_TWO_POLLS = 2
+EXPECT_THREE_POLLS = 3
+EXPECT_FOUR_POLLS = 4
+EXPECT_TWO_REQUESTS = 2
+EXPECT_FOUR_REQUESTS = 4
+ELAPSED_ONE_SECOND = 1.0
+ELAPSED_HALF_SECOND = 0.5
+ELAPSED_TWO_SECONDS = 2.0
+ELAPSED_THREE_SECONDS = 3.0
+ELAPSED_FOUR_SECONDS = 4.0
+EXPECT_ELAPSED_2_5 = 2.5
+CUSTOM_TIMEOUT_SECONDS = 10.0
+EXPECT_ELAPSED_30_5 = 30.5
+DEFAULT_TIMEOUT_SECONDS = 30.0
+TIMEOUT_POLL_OVERSHOOT = 35
+
+
+@dataclass(frozen=True)
+class RecordedRequest:
+    """Captured request for assertion."""
+
+    url: str
+    payload: dict[str, object]
+    headers: dict[str, str]
+    timeout_seconds: float | None
+    verify_tls: bool
+
+
+class MultiResponseTransport:
+    """Transport that returns a sequence of canned responses."""
+
+    def __init__(self, responses: Sequence[TransportResponse]) -> None:
+        self._responses = list(responses)
+        self._call_index = 0
+        self.recorded_requests: list[RecordedRequest] = []
+
+    def post_json(
+        self,
+        url: str,
+        payload: Mapping[str, object],
+        *,
+        headers: Mapping[str, str],
+        timeout_seconds: float | None,
+        verify_tls: bool,
+    ) -> TransportResponse:
+        self.recorded_requests.append(
+            RecordedRequest(
+                url=url,
+                payload=dict(payload),
+                headers=dict(headers),
+                timeout_seconds=timeout_seconds,
+                verify_tls=verify_tls,
+            ),
+        )
+        response = self._responses[self._call_index]
+        self._call_index += 1
+        return response
+
+
+def _make_response(payload: dict[str, object]) -> TransportResponse:
+    return TransportResponse(status_code=200, text=json.dumps(payload), headers={})
+
+
+def _success_payload(
+    parameters: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    if parameters is None:
+        return {
+            "overallCompletionCode": 0,
+            "overallReasonCode": 0,
+        }
+    return {
+        "commandResponse": [{"completionCode": 0, "reasonCode": 0, "parameters": params} for params in parameters],
+        "overallCompletionCode": 0,
+        "overallReasonCode": 0,
+    }
+
+
+def _build_session(
+    responses: Sequence[dict[str, object]],
+    *,
+    map_attributes: bool = True,
+) -> tuple[MQRESTSession, MultiResponseTransport]:
+    transport = MultiResponseTransport([_make_response(resp) for resp in responses])
+    session = MQRESTSession(
+        rest_base_url="https://example.invalid/ibmmq/rest/v2",
+        qmgr_name="QM1",
+        credentials=BasicAuth("user", TEST_PASSWORD),
+        transport=transport,
+        map_attributes=map_attributes,
+    )
+    return session, transport
+
+
+# ---------------------------------------------------------------------------
+# SyncConfig dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSyncConfig:
+    def test_defaults(self) -> None:
+        cfg = SyncConfig()
+        assert cfg.timeout_seconds == DEFAULT_TIMEOUT_SECONDS
+        assert cfg.poll_interval_seconds == ELAPSED_ONE_SECOND
+
+    def test_custom_values(self) -> None:
+        cfg = SyncConfig(timeout_seconds=10.0, poll_interval_seconds=0.5)
+        assert cfg.timeout_seconds == CUSTOM_TIMEOUT_SECONDS
+        assert cfg.poll_interval_seconds == ELAPSED_HALF_SECOND
+
+    def test_frozen(self) -> None:
+        cfg = SyncConfig()
+        with pytest.raises(AttributeError):
+            cfg.timeout_seconds = 99.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# SyncOperation enum
+# ---------------------------------------------------------------------------
+
+
+class TestSyncOperation:
+    def test_values(self) -> None:
+        assert SyncOperation.STARTED.value == "started"
+        assert SyncOperation.STOPPED.value == "stopped"
+        assert SyncOperation.RESTARTED.value == "restarted"
+
+    def test_members(self) -> None:
+        assert set(SyncOperation) == {
+            SyncOperation.STARTED,
+            SyncOperation.STOPPED,
+            SyncOperation.RESTARTED,
+        }
+
+
+# ---------------------------------------------------------------------------
+# SyncResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSyncResult:
+    def test_attributes(self) -> None:
+        result = SyncResult(SyncOperation.STARTED, polls=3, elapsed_seconds=2.5)
+        assert result.operation is SyncOperation.STARTED
+        assert result.polls == EXPECT_THREE_POLLS
+        assert result.elapsed_seconds == EXPECT_ELAPSED_2_5
+
+    def test_frozen(self) -> None:
+        result = SyncResult(SyncOperation.STOPPED, polls=1, elapsed_seconds=1.0)
+        with pytest.raises(AttributeError):
+            result.polls = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# MQRESTTimeoutError
+# ---------------------------------------------------------------------------
+
+
+class TestMQRESTTimeoutError:
+    def test_attributes(self) -> None:
+        err = MQRESTTimeoutError(
+            "timed out",
+            name="MY.CHL",
+            operation="start",
+            elapsed=30.5,
+        )
+        assert str(err) == "timed out"
+        assert err.name == "MY.CHL"
+        assert err.operation == "start"
+        assert err.elapsed == EXPECT_ELAPSED_30_5
+
+    def test_is_mqrest_error(self) -> None:
+        err = MQRESTTimeoutError("t", name="X", operation="stop", elapsed=1.0)
+        assert isinstance(err, MQRESTError)
+
+
+# ---------------------------------------------------------------------------
+# Fake clock fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _fake_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch time.sleep and time.monotonic for deterministic polling.
+
+    Each call to time.sleep advances the fake clock by the requested
+    number of seconds.
+    """
+    clock = [0.0]
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    def fake_sleep(seconds: float) -> None:
+        clock[0] += seconds
+
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+
+# ---------------------------------------------------------------------------
+# Channel start/stop/restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestStartChannelSync:
+    def test_running_on_first_poll(self) -> None:
+        start_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "RUNNING"}])
+        session, transport = _build_session([start_response, status_response])
+
+        result = session.start_channel_sync("MY.CHL")
+
+        assert result.operation is SyncOperation.STARTED
+        assert result.polls == EXPECT_ONE_POLL
+        assert result.elapsed_seconds == ELAPSED_ONE_SECOND
+        assert len(transport.recorded_requests) == EXPECT_TWO_REQUESTS
+        assert transport.recorded_requests[0].payload["command"] == "START"
+        assert transport.recorded_requests[0].payload["qualifier"] == "CHANNEL"
+        assert transport.recorded_requests[0].payload["name"] == "MY.CHL"
+        assert transport.recorded_requests[1].payload["command"] == "DISPLAY"
+        assert transport.recorded_requests[1].payload["qualifier"] == "CHSTATUS"
+
+    def test_running_after_multiple_polls(self) -> None:
+        start_response = _success_payload()
+        initializing = _success_payload([{"STATUS": "INITIALIZING"}])
+        running = _success_payload([{"STATUS": "RUNNING"}])
+        session, _transport = _build_session([start_response, initializing, initializing, running])
+
+        result = session.start_channel_sync("MY.CHL")
+
+        assert result.operation is SyncOperation.STARTED
+        assert result.polls == EXPECT_THREE_POLLS
+        assert result.elapsed_seconds == ELAPSED_THREE_SECONDS
+
+    def test_timeout_raises(self) -> None:
+        start_response = _success_payload()
+        initializing_responses = [_success_payload([{"STATUS": "INITIALIZING"}])] * TIMEOUT_POLL_OVERSHOOT
+        session, _transport = _build_session([start_response, *initializing_responses])
+
+        with pytest.raises(MQRESTTimeoutError) as exc_info:
+            session.start_channel_sync("MY.CHL")
+
+        assert exc_info.value.name == "MY.CHL"
+        assert exc_info.value.operation == "start"
+        assert exc_info.value.elapsed >= DEFAULT_TIMEOUT_SECONDS
+
+    def test_custom_config(self) -> None:
+        start_response = _success_payload()
+        running = _success_payload([{"STATUS": "RUNNING"}])
+        session, _transport = _build_session([start_response, running])
+
+        cfg = SyncConfig(timeout_seconds=5.0, poll_interval_seconds=0.5)
+        result = session.start_channel_sync("MY.CHL", config=cfg)
+
+        assert result.operation is SyncOperation.STARTED
+        assert result.elapsed_seconds == ELAPSED_HALF_SECOND
+
+    def test_works_with_mapping_disabled(self) -> None:
+        """Polling works when mapping is off (raw MQSC STATUS key)."""
+        start_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "RUNNING"}])
+        session, _transport = _build_session(
+            [start_response, status_response],
+            map_attributes=False,
+        )
+
+        result = session.start_channel_sync("MY.CHL")
+
+        assert result.operation is SyncOperation.STARTED
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestStopChannelSync:
+    def test_stopped_on_first_poll(self) -> None:
+        stop_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "STOPPED"}])
+        session, transport = _build_session([stop_response, status_response])
+
+        result = session.stop_channel_sync("MY.CHL")
+
+        assert result.operation is SyncOperation.STOPPED
+        assert result.polls == EXPECT_ONE_POLL
+        assert len(transport.recorded_requests) == EXPECT_TWO_REQUESTS
+        assert transport.recorded_requests[0].payload["command"] == "STOP"
+        assert transport.recorded_requests[0].payload["qualifier"] == "CHANNEL"
+
+    def test_empty_result_means_stopped_for_channel(self) -> None:
+        """Channels may disappear from CHSTATUS when stopped."""
+        stop_response = _success_payload()
+        empty_status = _success_payload()
+        session, _transport = _build_session([stop_response, empty_status])
+
+        result = session.stop_channel_sync("MY.CHL")
+
+        assert result.operation is SyncOperation.STOPPED
+        assert result.polls == EXPECT_ONE_POLL
+
+    def test_timeout_raises(self) -> None:
+        stop_response = _success_payload()
+        stopping_responses = [_success_payload([{"STATUS": "STOPPING"}])] * TIMEOUT_POLL_OVERSHOOT
+        session, _transport = _build_session([stop_response, *stopping_responses])
+
+        with pytest.raises(MQRESTTimeoutError) as exc_info:
+            session.stop_channel_sync("MY.CHL")
+
+        assert exc_info.value.name == "MY.CHL"
+        assert exc_info.value.operation == "stop"
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestRestartChannel:
+    def test_restart_sequence(self) -> None:
+        stop_response = _success_payload()
+        stopped_status = _success_payload([{"STATUS": "STOPPED"}])
+        start_response = _success_payload()
+        running_status = _success_payload([{"STATUS": "RUNNING"}])
+        session, transport = _build_session(
+            [stop_response, stopped_status, start_response, running_status],
+        )
+
+        result = session.restart_channel("MY.CHL")
+
+        assert result.operation is SyncOperation.RESTARTED
+        assert result.polls == EXPECT_TWO_POLLS
+        assert result.elapsed_seconds == ELAPSED_TWO_SECONDS
+        assert len(transport.recorded_requests) == EXPECT_FOUR_REQUESTS
+        assert transport.recorded_requests[0].payload["command"] == "STOP"
+        assert transport.recorded_requests[1].payload["command"] == "DISPLAY"
+        assert transport.recorded_requests[2].payload["command"] == "START"
+        assert transport.recorded_requests[3].payload["command"] == "DISPLAY"
+
+    def test_restart_combined_totals(self) -> None:
+        stop_response = _success_payload()
+        stopping = _success_payload([{"STATUS": "STOPPING"}])
+        stopped = _success_payload([{"STATUS": "STOPPED"}])
+        start_response = _success_payload()
+        initializing = _success_payload([{"STATUS": "INITIALIZING"}])
+        running = _success_payload([{"STATUS": "RUNNING"}])
+        session, _transport = _build_session(
+            [stop_response, stopping, stopped, start_response, initializing, running],
+        )
+
+        result = session.restart_channel("MY.CHL")
+
+        assert result.operation is SyncOperation.RESTARTED
+        assert result.polls == EXPECT_FOUR_POLLS
+        assert result.elapsed_seconds == ELAPSED_FOUR_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Listener start/stop/restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestStartListenerSync:
+    def test_running_on_first_poll(self) -> None:
+        start_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "RUNNING"}])
+        session, transport = _build_session([start_response, status_response])
+
+        result = session.start_listener_sync("MY.LIS")
+
+        assert result.operation is SyncOperation.STARTED
+        assert result.polls == EXPECT_ONE_POLL
+        assert len(transport.recorded_requests) == EXPECT_TWO_REQUESTS
+        assert transport.recorded_requests[0].payload["command"] == "START"
+        assert transport.recorded_requests[0].payload["qualifier"] == "LISTENER"
+        assert transport.recorded_requests[1].payload["qualifier"] == "LSSTATUS"
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestStopListenerSync:
+    def test_stopped_on_first_poll(self) -> None:
+        stop_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "STOPPED"}])
+        session, transport = _build_session([stop_response, status_response])
+
+        result = session.stop_listener_sync("MY.LIS")
+
+        assert result.operation is SyncOperation.STOPPED
+        assert result.polls == EXPECT_ONE_POLL
+        assert transport.recorded_requests[0].payload["qualifier"] == "LISTENER"
+
+    def test_empty_result_does_not_mean_stopped_for_listener(self) -> None:
+        """Unlike channels, listeners should NOT treat empty as stopped."""
+        stop_response = _success_payload()
+        empty_status = _success_payload()
+        more_empty = [_success_payload()] * TIMEOUT_POLL_OVERSHOOT
+        session, _transport = _build_session([stop_response, empty_status, *more_empty])
+
+        with pytest.raises(MQRESTTimeoutError):
+            session.stop_listener_sync("MY.LIS")
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestRestartListener:
+    def test_restart_sequence(self) -> None:
+        stop_response = _success_payload()
+        stopped_status = _success_payload([{"STATUS": "STOPPED"}])
+        start_response = _success_payload()
+        running_status = _success_payload([{"STATUS": "RUNNING"}])
+        session, transport = _build_session(
+            [stop_response, stopped_status, start_response, running_status],
+        )
+
+        result = session.restart_listener("MY.LIS")
+
+        assert result.operation is SyncOperation.RESTARTED
+        assert result.polls == EXPECT_TWO_POLLS
+        assert len(transport.recorded_requests) == EXPECT_FOUR_REQUESTS
+
+
+# ---------------------------------------------------------------------------
+# Service start/stop/restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestStartServiceSync:
+    def test_running_on_first_poll(self) -> None:
+        start_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "RUNNING"}])
+        session, transport = _build_session([start_response, status_response])
+
+        result = session.start_service_sync("MY.SVC")
+
+        assert result.operation is SyncOperation.STARTED
+        assert result.polls == EXPECT_ONE_POLL
+        assert len(transport.recorded_requests) == EXPECT_TWO_REQUESTS
+        assert transport.recorded_requests[0].payload["command"] == "START"
+        assert transport.recorded_requests[0].payload["qualifier"] == "SERVICE"
+        assert transport.recorded_requests[1].payload["qualifier"] == "SVSTATUS"
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestStopServiceSync:
+    def test_stopped_on_first_poll(self) -> None:
+        stop_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "STOPPED"}])
+        session, transport = _build_session([stop_response, status_response])
+
+        result = session.stop_service_sync("MY.SVC")
+
+        assert result.operation is SyncOperation.STOPPED
+        assert result.polls == EXPECT_ONE_POLL
+        assert transport.recorded_requests[0].payload["qualifier"] == "SERVICE"
+
+    def test_empty_result_does_not_mean_stopped_for_service(self) -> None:
+        """Unlike channels, services should NOT treat empty as stopped."""
+        stop_response = _success_payload()
+        empty_responses = [_success_payload()] * (TIMEOUT_POLL_OVERSHOOT + 1)
+        session, _transport = _build_session([stop_response, *empty_responses])
+
+        with pytest.raises(MQRESTTimeoutError):
+            session.stop_service_sync("MY.SVC")
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestRestartService:
+    def test_restart_sequence(self) -> None:
+        stop_response = _success_payload()
+        stopped_status = _success_payload([{"STATUS": "STOPPED"}])
+        start_response = _success_payload()
+        running_status = _success_payload([{"STATUS": "RUNNING"}])
+        session, transport = _build_session(
+            [stop_response, stopped_status, start_response, running_status],
+        )
+
+        result = session.restart_service("MY.SVC")
+
+        assert result.operation is SyncOperation.RESTARTED
+        assert result.polls == EXPECT_TWO_POLLS
+        assert len(transport.recorded_requests) == EXPECT_FOUR_REQUESTS
+
+
+# ---------------------------------------------------------------------------
+# Parametrized: correct qualifiers for all object types
+# ---------------------------------------------------------------------------
+
+_OBJECT_TYPE_PARAMS = [
+    ("start_channel_sync", "START", "CHANNEL", "CHSTATUS"),
+    ("start_listener_sync", "START", "LISTENER", "LSSTATUS"),
+    ("start_service_sync", "START", "SERVICE", "SVSTATUS"),
+    ("stop_channel_sync", "STOP", "CHANNEL", "CHSTATUS"),
+    ("stop_listener_sync", "STOP", "LISTENER", "LSSTATUS"),
+    ("stop_service_sync", "STOP", "SERVICE", "SVSTATUS"),
+]
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestObjectTypeQualifiers:
+    @pytest.mark.parametrize(
+        ("method_name", "expected_command", "expected_qualifier", "expected_status_qualifier"),
+        _OBJECT_TYPE_PARAMS,
+        ids=[p[0] for p in _OBJECT_TYPE_PARAMS],
+    )
+    def test_correct_qualifiers_sent(
+        self,
+        method_name: str,
+        expected_command: str,
+        expected_qualifier: str,
+        expected_status_qualifier: str,
+    ) -> None:
+        command_response = _success_payload()
+        target_status = "RUNNING" if expected_command == "START" else "STOPPED"
+        status_response = _success_payload([{"STATUS": target_status}])
+        session, transport = _build_session([command_response, status_response])
+
+        method = getattr(session, method_name)
+        method("TEST.OBJ")
+
+        assert transport.recorded_requests[0].payload["command"] == expected_command
+        assert transport.recorded_requests[0].payload["qualifier"] == expected_qualifier
+        assert transport.recorded_requests[1].payload["command"] == "DISPLAY"
+        assert transport.recorded_requests[1].payload["qualifier"] == expected_status_qualifier
+
+
+# ---------------------------------------------------------------------------
+# Polling with mapping disabled (raw MQSC status keys)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_fake_clock")
+class TestMappingDisabledStatusKeys:
+    """Verify polling works with mapping disabled (raw MQSC keys)."""
+
+    def test_listener_raw_status_key(self) -> None:
+        start_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "RUNNING"}])
+        session, _transport = _build_session(
+            [start_response, status_response],
+            map_attributes=False,
+        )
+
+        result = session.start_listener_sync("MY.LIS")
+
+        assert result.operation is SyncOperation.STARTED
+
+    def test_service_raw_status_key(self) -> None:
+        start_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "RUNNING"}])
+        session, _transport = _build_session(
+            [start_response, status_response],
+            map_attributes=False,
+        )
+
+        result = session.start_service_sync("MY.SVC")
+
+        assert result.operation is SyncOperation.STARTED
+
+    def test_channel_raw_status_key(self) -> None:
+        stop_response = _success_payload()
+        status_response = _success_payload([{"STATUS": "STOPPED"}])
+        session, _transport = _build_session(
+            [stop_response, status_response],
+            map_attributes=False,
+        )
+
+        result = session.stop_channel_sync("MY.CHL")
+
+        assert result.operation is SyncOperation.STOPPED


### PR DESCRIPTION
## Summary

- Add `MQRESTSyncMixin` with 9 public methods (`start_*_sync`, `stop_*_sync`, `restart_*`) for channels, listeners, and services that poll `DISPLAY *STATUS` until the object reaches a stable state
- Add `SyncConfig`, `SyncOperation`, `SyncResult` public types and `MQRESTTimeoutError` exception
- Add Sphinx feature documentation (`sync-methods.md`) with examples and API reference page (`api/sync.md`)

Fixes #199

## Test plan

- [ ] `uv run python3 scripts/dev/validate_local.py` passes (100% coverage, ruff, mypy, ty)
- [ ] 36 new tests in `test_sync.py` cover all methods, timeouts, restart combined totals, mapping-disabled mode, channel empty-means-stopped edge case, and parametrized qualifier verification
- [ ] Sphinx docs build without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)