### PR TITLE
docs: add developer setup and contributing guides

### DIFF
--- a/docs/sphinx/development/contributing.md
+++ b/docs/sphinx/development/contributing.md
@@ -1,0 +1,92 @@
+# Contributing
+
+This project welcomes contributions from humans working with or without
+AI assistance. AI tooling is available but not required.
+
+## Branching and workflow
+
+All contributors follow the same branching model:
+
+- Branch from `develop` using `feature/*`, `bugfix/*`, `hotfix/*`, or
+  `chore/*` prefixes.
+- Commit messages follow
+  [conventional commits](https://www.conventionalcommits.org/) and are
+  validated by CI.
+- PR body must include `Fixes #N` or `Ref #N` (validated by CI).
+- Feature PRs: squash merge to `develop`.
+- Release PRs: regular merge to `main` (preserves shared ancestry).
+
+See {doc}`release-workflow` for the full release process.
+
+## Code quality gates
+
+Every PR must pass these gates, enforced both locally and in CI:
+
+| Gate | Tool |
+| --- | --- |
+| Linting | Ruff with all rules enabled (`select = ["ALL"]`) |
+| Formatting | Ruff format |
+| Type checking | mypy (strict) and ty |
+| Test coverage | pytest with 100% branch coverage |
+| Security audit | pip-audit |
+| Markdown lint | markdownlint |
+| Commit messages | Conventional commit validation |
+
+Run the full suite locally before pushing:
+
+```bash
+uv run python3 scripts/dev/validate_local.py
+```
+
+For docs-only changes:
+
+```bash
+uv run python3 scripts/dev/validate_docs.py
+```
+
+## For human contributors
+
+- Run `validate_local.py` before pushing to catch issues early.
+- Reference `docs/repository-standards.md` for the full standards
+  specification.
+- The `CLAUDE.md` and `AGENTS.md` files document architecture,
+  patterns, and key design decisions. They are useful as reference
+  material even when not using an AI agent.
+- After changing mapping data in `mapping_data.py`, regenerate
+  downstream artifacts. See {doc}`generation-scripts` for the
+  regeneration workflow.
+
+## For AI agent contributors
+
+### Agent entry points
+
+- **Claude Code**: reads `CLAUDE.md`, which loads repository standards
+  via include directives.
+- **Codex and other agents**: reads `AGENTS.md`, which loads the same
+  standards plus shared skills from the `standards-and-conventions`
+  repository.
+
+### Quality expectations
+
+AI-generated code must pass all the same validation gates listed
+above. There are no exceptions.
+
+### What AI agents handle well
+
+- Code generation from mapping data
+- Test writing and coverage gap filling
+- Linting and formatting fixes
+- Refactoring with consistent patterns
+- PR creation and submission
+
+### What requires human judgment
+
+- Architectural decisions and API design
+- MQ domain knowledge and MQSC semantics
+- Release decisions and version management
+- Mapping data curation (attribute names, value translations)
+
+### Co-author trailers
+
+AI agents add co-author trailers to commits automatically when
+following the repository standards.

--- a/docs/sphinx/development/developer-setup.md
+++ b/docs/sphinx/development/developer-setup.md
@@ -1,0 +1,122 @@
+# Developer setup
+
+This guide covers everything needed to develop and test pymqrest
+locally.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+| --- | --- | --- |
+| Python | 3.12+ | Runtime |
+| `uv` | 0.9.26 | Package and environment management |
+| Docker | Latest | Local MQ containers (integration tests) |
+| `markdownlint` | Latest | Docs validation |
+| `git-cliff` | Latest | Changelog generation (releases only) |
+
+Install `uv`:
+
+```bash
+python3 -m pip install uv==0.9.26
+```
+
+## Required repositories
+
+pymqrest depends on two sibling repositories:
+
+| Repository | Purpose |
+| --- | --- |
+| [pymqrest](https://github.com/wphillipmoore/pymqrest) | This project |
+| [standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
+| [mq-dev-environment](https://github.com/wphillipmoore/mq-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
+
+## Recommended directory layout
+
+Clone all three repositories as siblings:
+
+```text
+~/dev/
+├── pymqrest/
+├── standards-and-conventions/
+└── mq-dev-environment/
+```
+
+```bash
+cd ~/dev
+git clone https://github.com/wphillipmoore/pymqrest.git
+git clone https://github.com/wphillipmoore/standards-and-conventions.git
+git clone https://github.com/wphillipmoore/mq-dev-environment.git
+```
+
+## Initial setup
+
+```bash
+cd pymqrest
+
+# Install all dependencies including dev group
+uv sync --group dev
+
+# Enable repository git hooks
+git config core.hooksPath scripts/git-hooks
+```
+
+## Running validation
+
+The full validation suite matches CI hard gates:
+
+```bash
+uv run python3 scripts/dev/validate_local.py
+```
+
+This runs:
+
+- Virtual environment validation
+- Dependency specification validation
+- Version validation
+- Repository profile linting
+- Markdown standards checking
+- Commit message validation
+- Lock file verification
+- Security audit (`pip-audit`)
+- Ruff linting and formatting
+- mypy strict type checking
+- ty type checking
+- pytest with 100% branch coverage
+
+For docs-only changes, a lighter validation is available:
+
+```bash
+uv run python3 scripts/dev/validate_docs.py
+```
+
+## Running integration tests
+
+Integration tests require running MQ containers. Start the containers,
+seed test objects, then run the tests:
+
+```bash
+# Start both queue managers
+./scripts/dev/mq_start.sh
+
+# Seed deterministic test objects
+./scripts/dev/mq_seed.sh
+
+# Run integration tests
+PYMQREST_RUN_INTEGRATION=1 uv run pytest -m integration
+```
+
+See {doc}`local-mq-container` for full container configuration,
+credentials, gateway routing, and troubleshooting.
+
+## CI pipeline overview
+
+CI runs on every pull request and enforces the same gates as local
+validation. The pipeline includes:
+
+- **Unit tests** on Python 3.12, 3.13, and 3.14
+- **Integration tests** against real MQ queue managers via the shared
+  `wphillipmoore/mq-dev-environment/.github/actions/setup-mq` action
+- **Standards compliance** (ruff, mypy, ty, markdown lint, commit
+  messages, repository profile)
+- **Dependency audit** (`pip-audit`)
+- **Release gates** (version checks, changelog validation) for PRs
+  targeting `main`

--- a/docs/sphinx/development/index.md
+++ b/docs/sphinx/development/index.md
@@ -3,6 +3,8 @@
 ```{toctree}
 :maxdepth: 2
 
+developer-setup
+contributing
 local-mq-container
 generation-scripts
 namespace-origin


### PR DESCRIPTION
## Summary

- Add `developer-setup.md` covering prerequisites, repository layout, initial setup, validation, integration tests, and CI overview
- Add `contributing.md` covering branching workflow, code quality gates, and guidance for both human and AI agent contributors
- Reorder the Development toctree so onboarding pages appear first

Docs-only: tests skipped

Files changed:
- `docs/sphinx/development/developer-setup.md` (new)
- `docs/sphinx/development/contributing.md` (new)
- `docs/sphinx/development/index.md` (modified)

## Issue Linkage

- Fixes #213

## Testing

- markdownlint
- `uv run python3 scripts/dev/validate_docs.py`

## Notes

- Cross-references existing pages via `{doc}` roles rather than duplicating content