### PR TITLE
fix: use PR_BUMP_TOKEN for version bump PR creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Create version bump PR
         if: steps.bump_check.outputs.needed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_PR_BUMP_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_BUMP_TOKEN || github.token }}
         run: |
           git remote set-url origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"


### PR DESCRIPTION
## Summary

- Change `GITHUB_PR_BUMP_TOKEN` to `PR_BUMP_TOKEN` in the publish workflow's version bump step
- GitHub does not allow repository secrets prefixed with `GITHUB_`, so the secret could never be stored under that name
- Falls back to `github.token` if `PR_BUMP_TOKEN` is not configured

## Issue Linkage

- Fixes #218

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- With the PAT, the bump PR will trigger CI and auto-merge normally
- Without the PAT (fallback), the PR is created but CI may need manual trigger
