### PR TITLE
fix: prevent release-gates skipped status from blocking auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,30 +63,35 @@ jobs:
   release-gates:
     name: release-gates
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
+      - name: Skip on non-PR events
+        if: github.event_name != 'pull_request'
+        run: echo "Not a pull request; skipping release gates."
+
       - name: Checkout code
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.14
+        if: github.event_name == 'pull_request'
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
 
       - name: PyPI version gates (PRs targeting main)
-        if: github.base_ref == 'main'
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
         run: |
           python3 scripts/dev/validate_pypi_version.py --check-not-exists
           python3 scripts/dev/validate_pypi_version.py --check-greater-than-latest
 
       - name: Changelog version gate (PRs targeting main)
-        if: github.base_ref == 'main'
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
         run: python3 scripts/dev/validate_changelog.py
 
       - name: Version divergence gate (PRs targeting develop)
-        if: github.base_ref == 'develop'
+        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
         run: |
           git fetch origin main --depth=1
           main_version=$(python3 -c "


### PR DESCRIPTION
## Summary

- Move the `pull_request` condition on the `release-gates` job from job-level `if:` to step-level `if:`
- On non-PR events (e.g. `push` to `release/**`), the job runs and passes trivially instead of being skipped
- On PR events, all validation steps execute as before

This prevents the required `release-gates` check from showing as "skipped" on push-triggered runs, which GitHub treats as unsatisfied for branch protection purposes.

Fixes #222

## Test plan

- [ ] `release-gates` shows as passed (not skipped) on push-triggered CI runs
- [ ] `release-gates` still validates version gates on PR events targeting `main`
- [ ] `release-gates` still validates version divergence on PR events targeting `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)