### PR TITLE
fix: update commit-message cutoff SHA to skip non-conventional squash merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Validate standards
         uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
         with:
-          commit-cutoff-sha: "479874c8779d058932928e2f6725b7a9eacefaa7"
+          commit-cutoff-sha: "df45093c260def11f409dc4f3ba86e91ec444797"
 
   dependency-audit:
     name: dependency-audit

--- a/scripts/lint/commit-messages.sh
+++ b/scripts/lint/commit-messages.sh
@@ -21,7 +21,7 @@ conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
 
 # Commits at or before this SHA predate the conventional commits convention
 # and are excluded from validation.
-CUTOFF_SHA="479874c8779d058932928e2f6725b7a9eacefaa7"
+CUTOFF_SHA="df45093c260def11f409dc4f3ba86e91ec444797"
 
 failed=0
 


### PR DESCRIPTION
## Summary

- Update commit-message cutoff SHA in both `ci.yml` and `scripts/lint/commit-messages.sh`
- Skips commit `df45093` which was a squash merge that used the PR title (missing `refactor:` prefix) as the commit message

Ref #220

## Test plan

- [ ] `standards-compliance` passes (commit-message validation no longer fails on the bad SHA)
- [ ] Local `validate_local.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)