### PR TITLE
chore: adopt canonical git hooks from standards-and-conventions

### DIFF
--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-commit_message_file="${1:-}"
-
-if [[ -z "$commit_message_file" ]]; then
-  echo "ERROR: commit message file path is required." >&2
-  exit 2
-fi
-
 repo_root="$(git rev-parse --show-toplevel)"
-"$repo_root/scripts/lint/commit-message.sh" "$commit_message_file"
+
+"$repo_root/scripts/lint/commit-message.sh" "$1"
+"$repo_root/scripts/lint/co-author.sh" "$1"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -3,21 +3,63 @@ set -euo pipefail
 
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
-if [[ -z "$current_branch" || "$current_branch" == "HEAD" ]]; then
-  echo "ERROR: unable to determine the current branch. Create a feature branch before committing." >&2
+# Block detached HEAD unconditionally.
+if [[ "$current_branch" == "HEAD" ]]; then
+  echo "ERROR: detached HEAD is not allowed for commits." >&2
+  echo "Create a short-lived branch and open a PR." >&2
   exit 1
 fi
 
+# Block commits to protected branches (universal set — safe for all models).
 case "$current_branch" in
-  develop|release|main)
+  develop|release|main|release/*)
     echo "ERROR: direct commits to protected branches are forbidden ($current_branch)." >&2
-    echo "Create a short-lived branch (feature/*, bugfix/*, hotfix/*) and open a PR." >&2
+    echo "Create a short-lived branch and open a PR." >&2
     exit 1
     ;;
 esac
 
-if [[ ! "$current_branch" =~ ^(feature|bugfix|hotfix|release|chore)/.+$ ]]; then
-  echo "ERROR: branch '$current_branch' does not follow the required prefix rules." >&2
-  echo "Allowed prefixes: feature/*, bugfix/*, hotfix/*, release/*, chore/*" >&2
+# Read branching_model from the repository profile.
+repo_root="$(git rev-parse --show-toplevel)"
+profile_file="$repo_root/docs/repository-standards.md"
+branching_model=""
+
+if [[ -f "$profile_file" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
+      branching_model="${BASH_REMATCH[1]}"
+      break
+    fi
+  done < "$profile_file"
+fi
+
+# Set allowed branch prefixes based on branching model.
+case "$branching_model" in
+  docs-single-branch)
+    allowed_regex='^(feature|bugfix)/'
+    allowed_display="feature/* or bugfix/*"
+    ;;
+  application-promotion)
+    allowed_regex='^(feature|bugfix|hotfix|promotion)/'
+    allowed_display="feature/*, bugfix/*, hotfix/*, or promotion/*"
+    ;;
+  library-release)
+    allowed_regex='^(feature|bugfix|hotfix)/'
+    allowed_display="feature/*, bugfix/*, or hotfix/*"
+    ;;
+  "")
+    echo "WARNING: branching_model not found in $profile_file; falling back to feature/*/bugfix/*." >&2
+    allowed_regex='^(feature|bugfix)/'
+    allowed_display="feature/* or bugfix/*"
+    ;;
+  *)
+    echo "ERROR: unrecognized branching_model '$branching_model' in $profile_file." >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$current_branch" =~ $allowed_regex ]]; then
+  echo "ERROR: branch name must use $allowed_display ($current_branch)." >&2
+  echo "Rename the branch before committing." >&2
   exit 1
 fi

--- a/scripts/lint/co-author.sh
+++ b/scripts/lint/co-author.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_message_file="${1:-}"
+
+if [[ -z "$commit_message_file" || ! -f "$commit_message_file" ]]; then
+  echo "ERROR: commit message file path is required." >&2
+  exit 2
+fi
+
+# Extract Co-Authored-By trailers from the commit message (case-insensitive match).
+trailers=()
+while IFS= read -r line; do
+  trailers+=("$line")
+done < <(grep -i '^Co-Authored-By:' "$commit_message_file" || true)
+
+# Human-only commits (no trailers) are valid.
+if [[ ${#trailers[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Read approved identities from the repository profile.
+repo_root="$(git rev-parse --show-toplevel)"
+profile_file="$repo_root/docs/repository-standards.md"
+
+if [[ ! -f "$profile_file" ]]; then
+  echo "ERROR: repository profile not found at $profile_file; cannot validate co-author trailers." >&2
+  exit 1
+fi
+
+approved=()
+while IFS= read -r line; do
+  approved+=("$line")
+done < <(grep -i '^\- Co-Authored-By:' "$profile_file" | sed 's/^- //' || true)
+
+if [[ ${#approved[@]} -eq 0 ]]; then
+  echo "ERROR: no approved co-author identities found in $profile_file." >&2
+  exit 1
+fi
+
+# Validate each trailer against the approved list.
+failed=0
+for trailer in "${trailers[@]}"; do
+  # Normalize whitespace for comparison.
+  normalized="$(echo "$trailer" | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//')"
+  match=0
+  for identity in "${approved[@]}"; do
+    normalized_identity="$(echo "$identity" | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//')"
+    if [[ "$normalized" == "$normalized_identity" ]]; then
+      match=1
+      break
+    fi
+  done
+  if [[ $match -eq 0 ]]; then
+    echo "ERROR: unapproved co-author trailer: $trailer" >&2
+    echo "Approved identities are listed in $profile_file under 'AI co-authors'." >&2
+    failed=1
+  fi
+done
+
+exit $failed


### PR DESCRIPTION
## Summary

- Replace local git hooks with canonical branching-model-aware implementation from standards-and-conventions
- Pre-commit hook now reads `branching_model: library-release` from repo profile, enabling `feature/*`, `bugfix/*`, `hotfix/*` prefixes
- Add co-author trailer validation (`scripts/lint/co-author.sh`) wired into `commit-msg` hook
- Drop non-standard `release/*` and `chore/*` short-lived branch prefixes

Fixes #227

## Test plan

- [x] Pre-commit hook passes on `feature/*` branch with `library-release` model
- [x] Co-author validation passes with approved trailers
- [x] Co-author validation rejects unapproved trailers
- [x] Human-only commits (no trailers) pass co-author validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)