### PR TITLE
feat: adopt per-project MQ container isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,8 @@ jobs:
 
       - name: Setup MQ environment
         uses: wphillipmoore/mq-dev-environment/.github/actions/setup-mq@main
+        with:
+          project-name: pymqrest
 
       - name: Run integration tests
         run: |

--- a/scripts/dev/mq_reset.sh
+++ b/scripts/dev/mq_reset.sh
@@ -10,5 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
+export COMPOSE_PROJECT_NAME=pymqrest
+
 cd "$mq_dev_env"
 exec scripts/mq_reset.sh

--- a/scripts/dev/mq_seed.sh
+++ b/scripts/dev/mq_seed.sh
@@ -10,5 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
+export COMPOSE_PROJECT_NAME=pymqrest
+
 cd "$mq_dev_env"
 exec scripts/mq_seed.sh

--- a/scripts/dev/mq_start.sh
+++ b/scripts/dev/mq_start.sh
@@ -10,5 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
+export COMPOSE_PROJECT_NAME=pymqrest
+
 cd "$mq_dev_env"
 exec scripts/mq_start.sh

--- a/scripts/dev/mq_stop.sh
+++ b/scripts/dev/mq_stop.sh
@@ -10,5 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
+export COMPOSE_PROJECT_NAME=pymqrest
+
 cd "$mq_dev_env"
 exec scripts/mq_stop.sh

--- a/scripts/dev/mq_verify.sh
+++ b/scripts/dev/mq_verify.sh
@@ -10,5 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
+export COMPOSE_PROJECT_NAME=pymqrest
+
 cd "$mq_dev_env"
 exec scripts/mq_verify.sh


### PR DESCRIPTION
## Summary

- Set `COMPOSE_PROJECT_NAME=pymqrest` in all 5 MQ lifecycle wrapper scripts (`mq_start.sh`, `mq_stop.sh`, `mq_seed.sh`, `mq_verify.sh`, `mq_reset.sh`)
- Pass `project-name: pymqrest` to the `setup-mq` CI action in `ci.yml`
- Enables multiple projects to run integration tests simultaneously without container or port naming collisions

Fixes #232

## Test plan

- [ ] `uv run python3 scripts/dev/validate_local.py` passes
- [ ] CI integration tests pass with the new `project-name` input
- [ ] Local MQ lifecycle scripts create containers namespaced under `pymqrest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)