### PR TITLE
fix: allow release/* commits in library-release branching model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.3] - 2026-02-15
+
+### Bug fixes
+
+- add missing MAPPING_DATA entries for integration test failures (#236)
+
+### Documentation
+
+- add nested object flattening design doc and queue status example (#240)
+
+### Features
+
+- adopt per-project MQ container isolation (#233)
+
 ## [1.1.2] - 2026-02-13
 
 ### Bug fixes
 
 - use PR_BUMP_TOKEN for version bump PR creation (#219)
+- prevent release-gates skipped status from blocking auto-merge (#223)
 
 ## [1.1.1] - 2026-02-13
 

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -12,7 +12,7 @@ fi
 
 # Block commits to protected branches (universal set — safe for all models).
 case "$current_branch" in
-  develop|release|main|release/*)
+  develop|release|main)
     echo "ERROR: direct commits to protected branches are forbidden ($current_branch)." >&2
     echo "Create a short-lived branch and open a PR." >&2
     exit 1
@@ -44,8 +44,8 @@ case "$branching_model" in
     allowed_display="feature/*, bugfix/*, hotfix/*, or promotion/*"
     ;;
   library-release)
-    allowed_regex='^(feature|bugfix|hotfix)/'
-    allowed_display="feature/*, bugfix/*, or hotfix/*"
+    allowed_regex='^(feature|bugfix|hotfix|release)/'
+    allowed_display="feature/*, bugfix/*, hotfix/*, or release/*"
     ;;
   "")
     echo "WARNING: branching_model not found in $profile_file; falling back to feature/*/bugfix/*." >&2


### PR DESCRIPTION
## Summary

- Remove `release/*` from the hard-blocked protected branch list in the pre-commit hook
- Add `release` as an allowed branch prefix for the `library-release` branching model

The canonical pre-commit hook adopted in #228 blocked commits on `release/*`
branches, but `prepare_release.py` needs to commit changelog updates there
as part of the library-release flow.

## Issue Linkage

- Fixes #243

## Testing

- `uv run python3 scripts/dev/validate_local.py` — all checks pass
- Docs-only exception does not apply (shell script change)

## Notes

- This fix is blocking the 1.1.3 release.
- The upstream canonical hook in standards-and-conventions should also be
  updated to match.