### PR TITLE
docs: fix attribute names, stale auth claim, and bare pages

### DIFF
--- a/docs/site/docs/api/commands.md
+++ b/docs/site/docs/api/commands.md
@@ -18,7 +18,7 @@ response_parameters
 `DISPLAY` methods also accept:
 
 where
-: Filter expression (e.g. `"current_depth GT 100"`). The keyword is
+: Filter expression (e.g. `"current_queue_depth GT 100"`). The keyword is
   mapped from `snake_case` when mapping is enabled.
 
 ## Return types

--- a/docs/site/docs/api/index.md
+++ b/docs/site/docs/api/index.md
@@ -1,1 +1,11 @@
 # API Reference
+
+Detailed documentation for the `pymqrest` public API.
+
+- [Session](session.md) — `MQRESTSession` class and construction options
+- [Authentication](auth.md) — Credential types (LTPA, Basic, Certificate)
+- [Commands](commands.md) — Complete list of MQSC command methods
+- [Ensure](ensure.md) — Idempotent object management methods
+- [Sync](sync.md) — Synchronous polling operations
+- [Mapping](mapping.md) — Attribute mapping internals
+- [Exceptions](exceptions.md) — Error types and handling patterns

--- a/docs/site/docs/design/index.md
+++ b/docs/site/docs/design/index.md
@@ -1,1 +1,7 @@
 # Design
+
+Architecture and design decisions behind `pymqrest`.
+
+- [Rationale](rationale.md) — Why the library exists and key design choices
+- [runCommandJSON Endpoint](runcommand-endpoint.md) — The IBM MQ REST API endpoint that pymqrest wraps
+- [Nested Object Flattening](nested-object-flattening.md) — How nested response structures are normalized

--- a/docs/site/docs/design/rationale.md
+++ b/docs/site/docs/design/rationale.md
@@ -69,7 +69,7 @@ The mapping layer is the most complex part of `pymqrest`. This
 complexity exists because IBM MQ uses terse uppercase tokens (`CURDEPTH`,
 `DEFPSIST`, `CHLTYPE`) that are unfriendly in Python code. The mapping
 pipeline translates these to readable `snake_case` names
-(`current_depth`, `default_persistence`, `channel_type`) and back.
+(`current_queue_depth`, `default_persistence`, `channel_type`) and back.
 
 The translation is not a simple case conversion. The mapping tables were
 originally bootstrapped from IBM MQ 9.4 documentation, then customized
@@ -78,7 +78,7 @@ as the sole authoritative source (see [namespace origin](../development/namespac
 The tables contain:
 
 - **Key maps**: Attribute name translations (e.g. `CURDEPTH` ↔
-  `current_depth`).
+  `current_queue_depth`).
 - **Value maps**: Enumerated value translations (e.g. `"YES"` ↔
   `"yes"`, `"SVRCONN"` ↔ `"server_connection"`).
 - **Key-value maps**: Cases where both key and value change together.

--- a/docs/site/docs/design/runcommand-endpoint.md
+++ b/docs/site/docs/design/runcommand-endpoint.md
@@ -103,7 +103,13 @@ The MQ REST API requires a CSRF token header for non-GET requests.
 
 ## Authentication
 
-`pymqrest` uses HTTP Basic authentication. The `Authorization` header
-is constructed from the username and password provided at session
-creation. Other authentication methods (client certificates, token-based
-auth) are not currently supported.
+`pymqrest` supports three authentication methods:
+
+- **LTPA** (`LTPAAuth`): Cookie-based authentication via an initial login
+  request. This is the recommended method and the default used in all
+  examples and documentation.
+- **Basic** (`BasicAuth`): HTTP Basic authentication via the `Authorization`
+  header.
+- **Certificate** (`CertificateAuth`): Mutual TLS with client certificates.
+
+See [authentication](../api/auth.md) for details on each method.

--- a/docs/site/docs/development/index.md
+++ b/docs/site/docs/development/index.md
@@ -1,1 +1,10 @@
 # Development
+
+Guides for contributing to and developing `pymqrest`.
+
+- [Developer Setup](developer-setup.md) — Environment setup and prerequisites
+- [Contributing](contributing.md) — Contribution guidelines
+- [Local MQ Container](local-mq-container.md) — Docker-based MQ environment for testing
+- [Generation Scripts](generation-scripts.md) — How mapping data and command methods are generated
+- [Namespace Origin](namespace-origin.md) — How the snake_case attribute names were derived
+- [Release Workflow](release-workflow.md) — How releases are published

--- a/docs/site/docs/ensure-methods.md
+++ b/docs/site/docs/ensure-methods.md
@@ -51,7 +51,7 @@ session = MQRESTSession(
 result = session.ensure_qlocal(
     "APP.REQUEST.Q",
     request_parameters={
-        "max_q_depth": 50000,
+        "max_queue_depth": 50000,
         "description": "Application request queue",
     },
 )
@@ -61,7 +61,7 @@ assert result.action is EnsureAction.CREATED
 result = session.ensure_qlocal(
     "APP.REQUEST.Q",
     request_parameters={
-        "max_q_depth": 50000,
+        "max_queue_depth": 50000,
         "description": "Application request queue",
     },
 )
@@ -71,7 +71,7 @@ assert result.action is EnsureAction.UNCHANGED
 result = session.ensure_qlocal(
     "APP.REQUEST.Q",
     request_parameters={
-        "max_q_depth": 50000,
+        "max_queue_depth": 50000,
         "description": "Updated request queue",
     },
 )
@@ -170,17 +170,17 @@ The ensure pattern is designed for scripts that declare desired state:
 def configure_queue_manager(session):
     """Ensure queue manager attributes are set for production."""
     result = session.ensure_qmgr(request_parameters={
-        "statistics_queue": "on",
-        "statistics_channel": "on",
-        "monitoring_queue": "medium",
-        "monitoring_channel": "medium",
+        "queue_statistics": "on",
+        "channel_statistics": "on",
+        "queue_monitoring": "medium",
+        "channel_monitoring": "medium",
     })
     print(f"Queue manager: {result.action.value}")
 
     queues = {
-        "APP.REQUEST.Q": {"max_q_depth": 50000, "def_persistence": "yes"},
-        "APP.REPLY.Q": {"max_q_depth": 10000, "def_persistence": "no"},
-        "APP.DLQ": {"max_q_depth": 100000, "def_persistence": "yes"},
+        "APP.REQUEST.Q": {"max_queue_depth": 50000, "default_persistence": "yes"},
+        "APP.REPLY.Q": {"max_queue_depth": 10000, "default_persistence": "no"},
+        "APP.DLQ": {"max_queue_depth": 100000, "default_persistence": "yes"},
     }
 
     for name, attrs in queues.items():

--- a/docs/site/docs/examples.md
+++ b/docs/site/docs/examples.md
@@ -53,7 +53,7 @@ MQ_REST_BASE_URL_QM2=https://localhost:9444/ibmmq/rest/v2 \
 depth and flags queues approaching capacity:
 
 - Lists all local queues via `display_queue()`
-- Calculates depth percentage (`current_depth / max_depth`)
+- Calculates depth percentage (`current_queue_depth / max_queue_depth`)
 - Flags queues above a configurable threshold (default 80%)
 
 Set `DEPTH_THRESHOLD_PCT` to change the warning threshold:

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -1,5 +1,10 @@
 # Getting started
 
+## Prerequisites
+
+- **Python**: 3.12 or later
+- **IBM MQ**: A running queue manager with the administrative REST API enabled
+
 ## Installation
 
 Install `pymqrest` from source using [uv](https://docs.astral.sh/uv/):
@@ -41,7 +46,7 @@ follow the pattern `<verb>_<qualifier>` in lowercase:
 queues = session.display_queue(name="SYSTEM.*")
 
 for queue in queues:
-    print(queue["queue_name"], queue.get("current_depth"))
+    print(queue["queue_name"], queue.get("current_queue_depth"))
 ```
 
 ```python
@@ -60,9 +65,9 @@ MQSC parameter names. This applies to both request and response attributes:
 # With mapping enabled (default)
 queues = session.display_queue(
     name="MY.QUEUE",
-    response_parameters=["current_depth", "max_depth"],
+    response_parameters=["current_queue_depth", "max_queue_depth"],
 )
-# Returns: [{"queue_name": "MY.QUEUE", "current_depth": 0, "max_depth": 5000}]
+# Returns: [{"queue_name": "MY.QUEUE", "current_queue_depth": 0, "max_queue_depth": 5000}]
 
 # With mapping disabled
 queues = session.display_queue(
@@ -120,7 +125,7 @@ session = MQRESTSession(
             "queue": {
                 "response_key_map": {
                     "CURDEPTH": "queue_depth",        # override built-in "current_queue_depth"
-                    "MAXDEPTH": "queue_max_depth",     # override built-in "max_queue_depth"
+                    "MAXDEPTH": "queue_max_depth",    # override built-in "max_queue_depth"
                 },
             },
         },

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,9 +1,47 @@
 # pymqrest
 
-Python wrapper for the IBM MQ administrative REST API.
+## Overview
 
-`pymqrest` provides a Python-friendly interface to IBM MQ queue manager
+**pymqrest** provides a Python-friendly interface to IBM MQ queue manager
 administration via the `runCommandJSON` REST endpoint. It translates between
 Python `snake_case` attribute names and native MQSC parameter names, wraps
 every MQSC command as a typed method, and handles authentication, CSRF tokens,
 and error propagation.
+
+## Key features
+
+- **~144 command methods** covering all MQSC verbs and qualifiers
+- **Bidirectional attribute mapping** between developer-friendly names and MQSC parameters
+- **Idempotent ensure methods** for declarative object management
+- **Bulk sync operations** for configuration-as-code workflows
+- **Zero runtime dependencies** — stdlib only
+- **Transport abstraction** for easy testing with mock transports
+
+## Quick links
+
+- [Getting Started](getting-started.md) — Installation and first session
+- [Architecture](architecture.md) — How the library is organized
+- [Mapping Pipeline](mapping-pipeline.md) — Attribute translation details
+- [API Reference](api/index.md) — Class and method documentation
+- [Examples](examples.md) — Practical scripts for common tasks
+
+## Installation
+
+```bash
+pip install pymqrest
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv add pymqrest
+```
+
+## Status
+
+This project is in **beta**. The API surface, mapping tables, and return
+shapes are stable but may evolve.
+
+## License
+
+GNU General Public License v3.0

--- a/docs/site/docs/mapping-pipeline.md
+++ b/docs/site/docs/mapping-pipeline.md
@@ -13,7 +13,7 @@ IBM MQ uses multiple naming conventions depending on the interface:
   directly by `pymqrest`, but they form the intermediate namespace in
   the mapping pipeline.
 
-**Python names** (e.g. `current_depth`, `default_persistence`)
+**Python names** (e.g. `current_queue_depth`, `default_persistence`)
 : Human-readable `snake_case` names for use in Python code.
 
 The mapping pipeline translates between MQSC and Python names. PCF names
@@ -78,7 +78,7 @@ recognized and passed through without mapping.
 ## WHERE keyword mapping
 
 The `where` parameter on DISPLAY methods accepts a filter expression
-like `"current_depth GT 100"`. The first token (the keyword) is mapped
+like `"current_queue_depth GT 100"`. The first token (the keyword) is mapped
 from `snake_case` to the MQSC name. The rest of the expression is
 passed through unchanged.
 


### PR DESCRIPTION
## Summary

- Fix incorrect attribute names in documentation examples to match canonical
  `mapping-data.json` (`current_depth` → `current_queue_depth`, etc.)
- Fix stale auth claim in `runcommand-endpoint.md` (claimed only Basic auth)
- Enrich bare `index.md` home page with features, links, install, status
- Add prerequisites section to `getting-started.md`
- Add navigation content to bare section index pages (api, design, development)

## Issue Linkage

- Fixes #250
- Ref mq-rest-admin-common#5

## Testing

- `uv run mkdocs build -f docs/site/mkdocs.yml --strict` passes

Docs-only: tests skipped

Files changed: docs/site/docs/api/commands.md, docs/site/docs/api/index.md,
docs/site/docs/design/index.md, docs/site/docs/design/rationale.md,
docs/site/docs/design/runcommand-endpoint.md, docs/site/docs/development/index.md,
docs/site/docs/ensure-methods.md, docs/site/docs/examples.md,
docs/site/docs/getting-started.md, docs/site/docs/index.md,
docs/site/docs/mapping-pipeline.md

## Notes

- All attribute names verified against `mapping-data.json` (identical across
  Java, Go, and Python repos)