### PR TITLE
docs: medium-severity documentation consistency fixes

### DIFF
--- a/docs/site/docs/api/exceptions.md
+++ b/docs/site/docs/api/exceptions.md
@@ -12,31 +12,134 @@ Exception
     └── MQRESTTimeoutError     — sync operation timeouts
 ```
 
+## MQRESTError
+
+The base exception class. All library exceptions inherit from this class.
+
 ::: pymqrest.exceptions.MQRESTError
     options:
       show_bases: true
 
-::: pymqrest.exceptions.MQRESTAuthError
-    options:
-      members: true
-      show_bases: true
+## MQRESTTransportError
+
+Thrown when the HTTP request fails at the network level — connection refused,
+DNS resolution failure, TLS handshake error, etc.
+
+```python
+from pymqrest.exceptions import MQRESTTransportError
+
+try:
+    session.display_queue("MY.QUEUE")
+except MQRESTTransportError as err:
+    print(f"Cannot reach MQ: {err}")
+    print(f"Cause: {err.__cause__}")
+```
 
 ::: pymqrest.exceptions.MQRESTTransportError
     options:
       members: true
       show_bases: true
 
+## MQRESTResponseError
+
+Thrown when the HTTP request succeeds but the response cannot be parsed —
+invalid JSON, missing expected fields, unexpected response structure.
+
 ::: pymqrest.exceptions.MQRESTResponseError
     options:
       members: true
       show_bases: true
+
+## MQRESTAuthError
+
+Thrown when authentication or authorization fails — invalid credentials,
+expired tokens, insufficient permissions (HTTP 401/403).
+
+```python
+from pymqrest.exceptions import MQRESTAuthError
+
+try:
+    session.display_qmgr()
+except MQRESTAuthError as err:
+    print(f"Authentication failed: {err}")
+```
+
+::: pymqrest.exceptions.MQRESTAuthError
+    options:
+      members: true
+      show_bases: true
+
+## MQRESTCommandError
+
+Thrown when the MQSC command returns a non-zero completion or reason code. This
+is the most commonly caught exception — it indicates the command was delivered
+to MQ but the queue manager rejected it.
+
+```python
+from pymqrest.exceptions import MQRESTCommandError
+
+try:
+    session.define_qlocal("MY.QUEUE")
+except MQRESTCommandError as err:
+    print(f"Command failed: {err}")
+    print(f"Response payload: {err.payload}")
+```
+
+!!! note
+    For DISPLAY commands with no matches, MQ returns reason code 2085
+    (MQRC_UNKNOWN_OBJECT_NAME). The library treats this as an empty list
+    rather than raising an exception.
 
 ::: pymqrest.exceptions.MQRESTCommandError
     options:
       members: true
       show_bases: true
 
+## MQRESTTimeoutError
+
+Thrown when a polling operation exceeds the configured timeout duration.
+
+```python
+from pymqrest.exceptions import MQRESTTimeoutError
+
+try:
+    session.start_channel_sync("BROKEN.CHL")
+except MQRESTTimeoutError as err:
+    print(f"Object: {err.name}")
+    print(f"Operation: {err.operation}")
+    print(f"Elapsed: {err.elapsed:.1f}s")
+```
+
 ::: pymqrest.exceptions.MQRESTTimeoutError
     options:
       members: true
       show_bases: true
+
+## Catching exceptions
+
+Catch the base class for broad error handling, or specific subtypes for
+targeted recovery:
+
+```python
+from pymqrest.exceptions import (
+    MQRESTCommandError,
+    MQRESTAuthError,
+    MQRESTTransportError,
+    MQRESTError,
+)
+
+try:
+    session.define_qlocal("MY.QUEUE", request_parameters={"max_queue_depth": 50000})
+except MQRESTCommandError as err:
+    # MQSC command failed — check reason code in payload
+    print(f"Command failed: {err}")
+except MQRESTAuthError:
+    # Credentials rejected
+    print("Not authorized")
+except MQRESTTransportError:
+    # Network error
+    print("Connection failed")
+except MQRESTError as err:
+    # Catch-all for any other library exception
+    print(f"Unexpected error: {err}")
+```

--- a/docs/site/docs/api/index.md
+++ b/docs/site/docs/api/index.md
@@ -8,4 +8,5 @@ Detailed documentation for the `pymqrest` public API.
 - [Ensure](ensure.md) — Idempotent object management methods
 - [Sync](sync.md) — Synchronous polling operations
 - [Mapping](mapping.md) — Attribute mapping internals
+- [Transport](transport.md) — Transport protocol and mock testing
 - [Exceptions](exceptions.md) — Error types and handling patterns

--- a/docs/site/docs/api/session.md
+++ b/docs/site/docs/api/session.md
@@ -14,18 +14,5 @@ from `MQRESTEnsureMixin` (see [ensure](ensure.md)).
 
 ## Transport
 
-The transport layer abstracts HTTP communication. The default
-`RequestsTransport` uses the `requests` library. Custom transports
-can be injected for testing or alternative HTTP clients.
-
-::: pymqrest.session.TransportResponse
-    options:
-      members: false
-
-::: pymqrest.session.MQRESTTransport
-    options:
-      members: true
-
-::: pymqrest.session.RequestsTransport
-    options:
-      members: true
+See [Transport](transport.md) for the transport protocol, response type,
+and mock transport examples.

--- a/docs/site/docs/api/transport.md
+++ b/docs/site/docs/api/transport.md
@@ -1,0 +1,60 @@
+# Transport
+
+## Overview
+
+The transport layer abstracts HTTP communication from the session logic. The
+session builds `runCommandJSON` payloads and delegates HTTP delivery to a
+transport implementation. This separation enables testing the entire command
+pipeline without an MQ server by injecting a mock transport.
+
+## MQRESTTransport
+
+The transport protocol defines a single method for posting JSON payloads:
+
+::: pymqrest.session.MQRESTTransport
+    options:
+      members: true
+
+## TransportResponse
+
+An immutable result containing the HTTP response data:
+
+::: pymqrest.session.TransportResponse
+    options:
+      members: true
+
+## RequestsTransport
+
+The default transport implementation using the `requests` library:
+
+::: pymqrest.session.RequestsTransport
+    options:
+      members: true
+
+## Custom transport
+
+Implement the `MQRESTTransport` protocol to provide custom HTTP behavior or
+for testing. Because the protocol has a single method, a mock works naturally:
+
+```python
+from unittest.mock import MagicMock
+from pymqrest.session import MQRESTTransport, TransportResponse
+
+mock_transport = MagicMock(spec=MQRESTTransport)
+mock_transport.post_json.return_value = TransportResponse(
+    status_code=200,
+    text='{"commandResponse": []}',
+    headers={},
+)
+
+session = MQRESTSession(
+    rest_base_url="https://localhost:9443/ibmmq/rest/v2",
+    qmgr_name="QM1",
+    credentials=LTPAAuth("admin", "passw0rd"),
+    transport=mock_transport,
+)
+```
+
+This pattern is used extensively in the library's own test suite to verify
+command payload construction, response parsing, and error handling without
+network access.

--- a/docs/site/docs/architecture.md
+++ b/docs/site/docs/architecture.md
@@ -2,82 +2,52 @@
 
 ## Component overview
 
-`pymqrest` is organized around four core components:
+--8<-- "architecture/component-overview.md"
 
-**MQRESTSession** (`session.py`)
-: The main entry point. Owns authentication, base URL construction,
-  request/response handling, and diagnostic state. Inherits generated
-  command methods from `MQRESTCommandMixin`.
+In the Python implementation, the core components map to these modules:
 
-**MQRESTCommandMixin** (`commands.py`)
-: Provides ~144 generated MQSC command methods. Each method is a thin
-  wrapper that calls `_mqsc_command` with the correct command verb and
-  qualifier.
-
-**MQRESTEnsureMixin** (`ensure.py`)
-: Provides 16 idempotent `ensure_*` methods for declarative object
-  management. Each method checks current state with DISPLAY, then
-  DEFINE, ALTER, or no-ops as needed. Returns an `EnsureResult` enum.
-  `ensure_qmgr()` is a special singleton variant (no name, no DEFINE).
-  See [ensure methods](ensure-methods.md) for details.
-
-**Mapping pipeline** (`mapping.py`, `mapping_data.py`)
-: Bidirectional attribute translation between Python `snake_case` names
-  and native MQSC parameter names. Includes key mapping (attribute names),
-  value mapping (enumerated values), and key-value mapping (combined
-  name+value translations).
-
-**Exception hierarchy** (`exceptions.py`)
-: Structured error types for transport failures, malformed responses,
-  and MQSC command errors.
+- **`MQRESTSession`** (`session.py`): The main entry point. Owns
+  authentication, base URL construction, request/response handling, and
+  diagnostic state. Inherits generated command methods from
+  `MQRESTCommandMixin`.
+- **`MQRESTCommandMixin`** (`commands.py`): Provides ~144 generated MQSC
+  command methods. Each method is a thin wrapper that calls `_mqsc_command`
+  with the correct command verb and qualifier.
+- **`MQRESTEnsureMixin`** (`ensure.py`): Provides 16 idempotent `ensure_*`
+  methods for declarative object management. `ensure_qmgr()` is a special
+  singleton variant (no name, no DEFINE).
+- **Mapping pipeline** (`mapping.py`, `mapping_data.py`): Bidirectional
+  attribute translation between Python `snake_case` names and native MQSC
+  parameter names. See the [mapping pipeline](mapping-pipeline.md) for
+  details.
+- **Exception hierarchy** (`exceptions.py`): Structured error types rooted
+  at `MQRESTError`. All exceptions carry diagnostic context.
 
 ## Request lifecycle
 
-Every MQSC command follows the same path through the system:
+--8<-- "architecture/request-lifecycle.md"
 
-```text
-Method call (e.g. display_queue)
-  → _mqsc_command()
-    → Map request attributes (snake_case → MQSC)
-    → Map response parameter names
-    → Map WHERE keyword
-    → Build runCommandJSON payload
-    → Transport POST
-    → Parse JSON response
-    → Extract commandResponse items
-    → Flatten nested objects
-    → Map response attributes (MQSC → snake_case)
-  → Return list[dict]
+In Python, the command dispatcher is the internal `_mqsc_command()` method on
+`MQRESTSession`. Every public command method (e.g. `display_queue()`,
+`define_qlocal()`) delegates to it with the appropriate verb and qualifier.
+
+The session retains diagnostic state from the most recent command for
+inspection:
+
+```python
+session.display_queue("MY.QUEUE")
+
+session.last_command_payload    # the JSON sent to MQ
+session.last_response_payload   # the parsed JSON response
+session.last_http_status        # HTTP status code
+session.last_response_text      # raw response body
 ```
-
-### Build phase
-
-1. The command method calls `_mqsc_command` with the MQSC verb (e.g.
-   `DISPLAY`), qualifier (e.g. `QUEUE`), and user-supplied parameters.
-2. If mapping is enabled, request attributes are translated from
-   `snake_case` to MQSC parameter names via the qualifier's
-   `request_key_map` and `request_value_map`.
-3. Response parameter names are mapped similarly.
-4. A `WHERE` clause keyword, if provided, is mapped through the same
-   qualifier key maps.
-5. The `runCommandJSON` payload is assembled and sent via the transport.
-
-### Parse phase
-
-1. The JSON response is parsed and validated.
-2. Error codes (`overallCompletionCode`, `overallReasonCode`, per-item
-   `completionCode`/`reasonCode`) are checked. Errors raise
-   `MQRESTCommandError`.
-3. The `parameters` dict is extracted from each `commandResponse` item.
-4. Nested `objects` lists (e.g. from `DISPLAY CONN TYPE(HANDLE)`) are
-   flattened into the parent parameter set.
-5. If mapping is enabled, response attributes are translated from MQSC
-   to `snake_case`.
 
 ## Transport abstraction
 
-`MQRESTSession` does not call `requests` directly. Instead, it delegates
-to a `MQRESTTransport` protocol:
+--8<-- "architecture/transport-abstraction.md"
+
+In Python, the transport is defined by the `MQRESTTransport` protocol:
 
 ```python
 class MQRESTTransport(Protocol):
@@ -93,47 +63,51 @@ class MQRESTTransport(Protocol):
 ```
 
 The default implementation, `RequestsTransport`, wraps the `requests`
-library. Tests inject a mock transport to avoid network calls.
+library.
+
+For testing, inject a mock transport:
+
+```python
+from unittest.mock import MagicMock
+
+mock_transport = MagicMock(spec=MQRESTTransport)
+mock_transport.post_json.return_value = TransportResponse(
+    status_code=200,
+    text='{"commandResponse": []}',
+    headers={},
+)
+
+session = MQRESTSession(
+    rest_base_url="https://localhost:9443/ibmmq/rest/v2",
+    qmgr_name="QM1",
+    credentials=LTPAAuth("admin", "passw0rd"),
+    transport=mock_transport,
+)
+```
+
+This makes the entire command pipeline testable without an MQ server.
 
 ## Single-endpoint design
 
-All MQSC operations go through a single REST endpoint:
+--8<-- "architecture/single-endpoint-design.md"
 
-```text
-POST /ibmmq/rest/v2/admin/action/qmgr/{qmgr}/mqsc
-```
-
-The `runCommandJSON` payload specifies the MQSC verb, qualifier, object
-name, parameters, and response parameters. This design means `pymqrest`
-needs exactly one HTTP method and one URL pattern to cover all MQSC
-commands.
+In Python, this means every command method on `MQRESTSession` ultimately calls
+the same `post_json()` method on the transport with the same URL pattern. The
+only variation is the JSON payload content.
 
 ## Gateway routing
 
-The MQ REST API supports routing MQSC commands from a local **gateway** queue
-manager to a remote **target** queue manager over MQ channels. This is the
-same mechanism used by `runmqsc -w` and the MQ Console.
+--8<-- "architecture/gateway-routing.md"
 
-When `gateway_qmgr` is set on the session:
+In Python, configure gateway routing via the `gateway_qmgr` parameter:
 
-- The URL path targets the **remote** queue manager:
-  `POST /admin/action/qmgr/{TARGET_QM}/mqsc`
-- The `ibm-mq-rest-gateway-qmgr` HTTP header names the **local** queue
-  manager that routes the command.
-
-When `gateway_qmgr` is `None` (default), no gateway header is sent and the
-REST API talks directly to the queue manager in the URL. This makes the
-feature purely additive — existing sessions are unaffected.
-
-```text
-Client                     Gateway QM (QM1)              Target QM (QM2)
-  │                              │                              │
-  │  POST /qmgr/QM2/mqsc        │                              │
-  │  Header: gateway-qmgr=QM1   │                              │
-  │─────────────────────────────>│   MQSC via MQ channel        │
-  │                              │─────────────────────────────>│
-  │                              │<─────────────────────────────│
-  │<─────────────────────────────│                              │
+```python
+session = MQRESTSession(
+    rest_base_url="https://qm1-host:9443/ibmmq/rest/v2",
+    qmgr_name="QM2",           # target (remote) queue manager
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
+    gateway_qmgr="QM1",        # local gateway queue manager
+)
 ```
 
 ## Generated command methods

--- a/docs/site/docs/mapping-pipeline.md
+++ b/docs/site/docs/mapping-pipeline.md
@@ -13,10 +13,10 @@ IBM MQ uses multiple naming conventions depending on the interface:
   directly by `pymqrest`, but they form the intermediate namespace in
   the mapping pipeline.
 
-**Python names** (e.g. `current_queue_depth`, `default_persistence`)
-: Human-readable `snake_case` names for use in Python code.
+**Developer names** (e.g. `current_queue_depth`, `default_persistence`)
+: Human-readable `snake_case` names for use in application code.
 
-The mapping pipeline translates between MQSC and Python names. PCF names
+The mapping pipeline translates between MQSC and developer names. PCF names
 were used as an intermediate reference during the original extraction
 process that bootstrapped the mapping tables but do not appear at
 runtime.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -19,18 +19,18 @@ theme:
     - search.highlight
     - search.suggest
   palette:
-    - scheme: default
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
     - scheme: slate
       primary: indigo
       accent: indigo
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
 
 plugins:
   - search
@@ -80,6 +80,7 @@ nav:
       - Ensure: api/ensure.md
       - Sync: api/sync.md
       - Mapping: api/mapping.md
+      - Transport: api/transport.md
       - Exceptions: api/exceptions.md
   - Mappings:
       - mappings/index.md


### PR DESCRIPTION
## Summary

- Rewrite architecture.md to use `--8<--` shared fragment includes (matching Java pattern)
- Add transport mocking guidance to architecture.md
- Create api/transport.md with MQRESTTransport protocol documentation
- Rewrite exceptions.md with usage examples for each exception type
- Normalize "Python names" → "Developer names" in mapping-pipeline.md
- Set dark mode as default theme palette

Docs-only: tests skipped

Files changed: `docs/site/docs/api/exceptions.md`, `docs/site/docs/api/index.md`,
`docs/site/docs/api/session.md`, `docs/site/docs/api/transport.md`,
`docs/site/docs/architecture.md`, `docs/site/docs/mapping-pipeline.md`,
`docs/site/mkdocs.yml`

Fixes #252