### PR TITLE
docs: address cross-library documentation consistency nits

### DIFF
--- a/docs/site/docs/api/ensure.md
+++ b/docs/site/docs/api/ensure.md
@@ -1,21 +1,66 @@
-# Ensure methods
+# Ensure
 
-The ensure module provides idempotent object management methods.
-See [ensure methods](../ensure-methods.md) for a conceptual overview and usage examples.
+## Overview
+
+The ensure module provides the return types for the 16 idempotent ensure
+methods on `MQRESTSession`. These methods implement a declarative upsert
+pattern: DEFINE if the object does not exist, ALTER only attributes that differ,
+or no-op if the object already matches the desired state.
 
 ## EnsureAction
+
+An enum indicating the action taken by an ensure method:
+
+```python
+class EnsureAction(Enum):
+    CREATED    = "created"     # Object did not exist; DEFINE was issued
+    UPDATED    = "updated"     # Object existed but attributes differed; ALTER was issued
+    UNCHANGED  = "unchanged"   # Object already matched the desired state
+```
+
+## EnsureResult
+
+A named tuple containing the action taken and the list of attribute names that
+triggered the change (if any):
+
+```python
+class EnsureResult(NamedTuple):
+    action: EnsureAction       # What happened
+    changed: list[str]         # Attribute names that differed (empty for CREATED/UNCHANGED)
+```
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `action` | `EnsureAction` | What happened: `CREATED`, `UPDATED`, or `UNCHANGED` |
+| `changed` | `list[str]` | Attribute names that triggered an ALTER (in the caller's namespace) |
+
+## Usage
+
+```python
+result = session.ensure_qlocal("MY.QUEUE",
+    request_parameters={"max_queue_depth": 50000, "description": "App queue"})
+
+match result.action:
+    case EnsureAction.CREATED:
+        print("Queue created")
+    case EnsureAction.UPDATED:
+        print(f"Changed: {result.changed}")
+    case EnsureAction.UNCHANGED:
+        print("Already correct")
+```
+
+See [Ensure Methods](../ensure-methods.md) for the full conceptual overview,
+comparison logic, and the complete list of available ensure methods.
+
+## API reference
 
 ::: pymqrest.ensure.EnsureAction
     options:
       members: true
 
-## EnsureResult
-
 ::: pymqrest.ensure.EnsureResult
     options:
       members: true
-
-## MQRESTEnsureMixin
 
 ::: pymqrest.ensure.MQRESTEnsureMixin
     options:

--- a/docs/site/docs/api/index.md
+++ b/docs/site/docs/api/index.md
@@ -1,12 +1,24 @@
 # API Reference
 
-Detailed documentation for the `pymqrest` public API.
+## Core
 
 - [Session](session.md) — `MQRESTSession` class and construction options
-- [Authentication](auth.md) — Credential types (LTPA, Basic, Certificate)
-- [Commands](commands.md) — Complete list of MQSC command methods
+- [Commands](commands.md) — MQSC command methods
+- [Transport](transport.md) — `MQRESTTransport` protocol and mock testing
+
+## Authentication
+
+- [Auth](auth.md) — Credential types (LTPA, Basic, Certificate)
+
+## Mapping
+
+- [Mapping](mapping.md) — Attribute mapping internals and override modes
+
+## Exceptions
+
+- [Exceptions](exceptions.md) — Error types and handling patterns
+
+## Patterns
+
 - [Ensure](ensure.md) — Idempotent object management methods
 - [Sync](sync.md) — Synchronous polling operations
-- [Mapping](mapping.md) — Attribute mapping internals
-- [Transport](transport.md) — Transport protocol and mock testing
-- [Exceptions](exceptions.md) — Error types and handling patterns

--- a/docs/site/docs/api/mapping.md
+++ b/docs/site/docs/api/mapping.md
@@ -1,18 +1,94 @@
 # Mapping
 
-The mapping module translates between Python `snake_case` attribute
-names and native MQSC parameter names. See [mapping pipeline](../mapping-pipeline.md)
-for a conceptual overview.
+## Overview
 
-## Functions
+The mapping module provides bidirectional attribute translation between
+developer-friendly `snake_case` names and native MQSC parameter names. The
+mapper is used internally by `MQRESTSession` and is not typically called
+directly.
+
+See [Mapping Pipeline](../mapping-pipeline.md) for a conceptual overview of
+how mapping works.
+
+## Mapping functions
+
+The module exposes three public functions that perform the actual translation.
+These are called internally by `MQRESTSession` during command execution:
+
+- **`map_request_attributes()`** — Translates request parameters from
+  `snake_case` to MQSC before sending to the REST API. Performs key mapping,
+  value mapping, and key-value mapping in sequence.
+
+- **`map_response_attributes()`** — Translates a single response dict from
+  MQSC to `snake_case` after receiving from the REST API.
+
+- **`map_response_list()`** — Translates a list of response dicts (the common
+  return type for DISPLAY commands).
+
+The mapper performs three types of translation in each direction:
+
+- **Key mapping**: Attribute name translation (e.g. `current_queue_depth` ↔
+  `CURDEPTH`)
+- **Value mapping**: Enumerated value translation (e.g. `"yes"` ↔ `"YES"`,
+  `"server_connection"` ↔ `"SVRCONN"`)
+- **Key-value mapping**: Combined name+value translation for cases where both
+  key and value change together (e.g. `channel_type="server_connection"` →
+  `CHLTYPE("SVRCONN")`)
+
+## Mapping data
+
+The mapping tables are loaded from the JSON resource file at:
+
+```text
+pymqrest/mapping_data.json
+```
+
+The data is organized by qualifier (e.g. `queue`, `channel`, `qmgr`) with
+separate maps for request and response directions. Each qualifier contains:
+
+- `request_key_map` — `snake_case` → MQSC key mapping for requests
+- `request_value_map` — value translations for request attributes
+- `request_key_value_map` — combined key+value translations for requests
+- `response_key_map` — MQSC → `snake_case` key mapping for responses
+- `response_value_map` — value translations for response attributes
+
+The mapping data was originally bootstrapped from IBM MQ 9.4 documentation and
+covers all standard MQSC attributes across 42 qualifiers.
+
+## Diagnostics
+
+### MappingIssue
+
+Tracks mapping problems encountered during translation:
+
+- Unknown attribute names (not found in key map)
+- Unknown attribute values (not found in value map)
+- Ambiguous mappings
+
+In strict mode, any `MappingIssue` causes a `MappingError`. In lenient
+mode, issues are collected but the unmapped values pass through unchanged.
+
+### MappingError
+
+Raised when attribute mapping fails in strict mode. Contains the list of
+`MappingIssue` instances that caused the failure.
+
+```python
+try:
+    session.display_queue("MY.QUEUE",
+        response_parameters=["invalid_attribute_name"])
+except MappingError as e:
+    # e describes the unmappable attributes
+    print(e)
+```
+
+## API reference
 
 ::: pymqrest.mapping.map_request_attributes
 
 ::: pymqrest.mapping.map_response_attributes
 
 ::: pymqrest.mapping.map_response_list
-
-## Diagnostics
 
 ::: pymqrest.mapping.MappingIssue
 

--- a/docs/site/docs/api/session.md
+++ b/docs/site/docs/api/session.md
@@ -1,18 +1,139 @@
 # Session
 
+## Overview
+
 The `MQRESTSession` class is the main entry point for interacting with
-IBM MQ via the REST API. It inherits MQSC command methods from
-`MQRESTCommandMixin` (see [commands](commands.md)) and idempotent ensure methods
-from `MQRESTEnsureMixin` (see [ensure](ensure.md)).
+IBM MQ via the REST API. A session encapsulates connection details,
+authentication, attribute mapping configuration, and diagnostic state. It
+inherits MQSC command methods from `MQRESTCommandMixin` (see
+[commands](commands.md)) and idempotent ensure methods from
+`MQRESTEnsureMixin` (see [ensure](ensure.md)).
 
-## MQRESTSession
+## Creating a session
 
-::: pymqrest.session.MQRESTSession
-    options:
-      members: true
-      show_bases: true
+```python
+from pymqrest import MQRESTSession
+from pymqrest.auth import LTPAAuth
+
+session = MQRESTSession(
+    rest_base_url="https://localhost:9443/ibmmq/rest/v2",
+    qmgr_name="QM1",
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
+)
+```
+
+The constructor validates all required fields and constructs the transport,
+mapping data, and authentication state at creation time. Errors in
+configuration (e.g. invalid mapping overrides) are caught immediately.
+
+## Constructor parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `rest_base_url` | Required | Base URL of the MQ REST API (e.g. `https://host:9443/ibmmq/rest/v2`) |
+| `qmgr_name` | Required | Target queue manager name |
+| `credentials` | Required | Authentication credentials (`LTPAAuth`, `BasicAuth`, or `CertificateAuth`) |
+| `gateway_qmgr` | Optional | Gateway queue manager for remote routing |
+| `map_attributes` | Optional | Enable/disable attribute mapping (default: `True`) |
+| `mapping_strict` | Optional | Strict or lenient mapping mode (default: `True`) |
+| `mapping_overrides` | Optional | Custom mapping overrides (sparse merge) |
+| `verify_tls` | Optional | Verify server TLS certificates (default: `True`) |
+| `timeout` | Optional | Default request timeout in seconds |
+| `csrf_token` | Optional | Custom CSRF token value |
+| `transport` | Optional | Custom transport implementation |
+
+### Minimal example
+
+```python
+session = MQRESTSession(
+    rest_base_url="https://localhost:9443/ibmmq/rest/v2",
+    qmgr_name="QM1",
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
+)
+```
+
+### Full example
+
+```python
+session = MQRESTSession(
+    rest_base_url="https://mq-server.example.com:9443/ibmmq/rest/v2",
+    qmgr_name="QM2",
+    credentials=LTPAAuth("mqadmin", "mqadmin"),
+    gateway_qmgr="QM1",
+    map_attributes=True,
+    mapping_strict=False,
+    mapping_overrides=overrides,
+    verify_tls=True,
+    timeout=30,
+)
+```
+
+## Command methods
+
+The session provides ~144 command methods, one for each MQSC verb + qualifier
+combination. See [Commands](commands.md) for the full list.
+
+```python
+# DISPLAY commands return a list of dicts
+queues = session.display_queue("APP.*")
+
+# Queue manager singletons return a single dict or None
+qmgr = session.display_qmgr()
+
+# Non-DISPLAY commands return None (raise on error)
+session.define_qlocal("MY.QUEUE", request_parameters={"max_queue_depth": 50000})
+session.delete_queue("MY.QUEUE")
+```
+
+## Ensure methods
+
+The session provides 16 ensure methods for declarative object management. Each
+method implements an idempotent upsert: DEFINE if the object does not exist,
+ALTER only the attributes that differ, or no-op if already correct.
+
+```python
+result = session.ensure_qlocal("MY.QUEUE",
+    request_parameters={"max_queue_depth": 50000})
+# result.action is EnsureAction.CREATED, UPDATED, or UNCHANGED
+```
+
+See [Ensure Methods](../ensure-methods.md) for detailed usage and the full list
+of available ensure methods.
+
+## Diagnostic state
+
+The session retains the most recent request and response for inspection. This
+is useful for debugging command failures or understanding what the library sent
+to the MQ REST API:
+
+```python
+session.display_queue("MY.QUEUE")
+
+session.last_command_payload    # the JSON sent to MQ (dict)
+session.last_response_payload   # the parsed JSON response (dict)
+session.last_http_status        # HTTP status code (int)
+session.last_response_text      # raw response body (str)
+```
+
+### Diagnostic attributes
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `qmgr_name` | `str` | Queue manager name |
+| `gateway_qmgr` | `str \| None` | Gateway queue manager (or `None`) |
+| `last_http_status` | `int` | HTTP status code from last command |
+| `last_response_text` | `str` | Raw response body from last command |
+| `last_response_payload` | `dict` | Parsed response from last command |
+| `last_command_payload` | `dict` | Command sent in last request |
 
 ## Transport
 
 See [Transport](transport.md) for the transport protocol, response type,
 and mock transport examples.
+
+## API reference
+
+::: pymqrest.session.MQRESTSession
+    options:
+      members: true
+      show_bases: true

--- a/docs/site/docs/api/sync.md
+++ b/docs/site/docs/api/sync.md
@@ -1,27 +1,97 @@
-# Sync methods
+# Sync
 
-The sync module provides synchronous start/stop/restart wrappers.
-See [sync methods](../sync-methods.md) for a conceptual overview and usage examples.
+## Overview
+
+The sync module provides the types for the 9 synchronous start/stop/restart
+methods on `MQRESTSession`. These methods wrap fire-and-forget `START` and
+`STOP` commands with a polling loop that waits until the object reaches its
+target state or the timeout expires.
+
+## SyncOperation
+
+An enum indicating the operation that was performed:
+
+```python
+class SyncOperation(Enum):
+    STARTED    = "started"     # Object confirmed running
+    STOPPED    = "stopped"     # Object confirmed stopped
+    RESTARTED  = "restarted"   # Stop-then-start completed
+```
 
 ## SyncConfig
+
+Configuration controlling the polling behaviour:
+
+```python
+@dataclass
+class SyncConfig:
+    timeout: float = 30.0         # Max seconds before raising
+    poll_interval: float = 1.0    # Seconds between polls
+```
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `timeout` | `float` | Maximum seconds to wait before raising `MQRESTTimeoutError` |
+| `poll_interval` | `float` | Seconds between `DISPLAY *STATUS` polls |
+
+## SyncResult
+
+Contains the outcome of a sync operation:
+
+```python
+class SyncResult(NamedTuple):
+    operation: SyncOperation   # What happened
+    polls: int                 # Number of status polls issued
+    elapsed: float             # Wall-clock seconds from command to confirmation
+```
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `operation` | `SyncOperation` | What happened: `STARTED`, `STOPPED`, or `RESTARTED` |
+| `polls` | `int` | Number of status polls issued |
+| `elapsed` | `float` | Wall-clock seconds from command to confirmation |
+
+## Method signature pattern
+
+All 9 sync methods follow the same signature pattern:
+
+```python
+result = session.start_channel_sync("TO.PARTNER")
+result = session.start_channel_sync("TO.PARTNER", config=SyncConfig(timeout=60))
+```
+
+## Usage
+
+```python
+from pymqrest.sync import SyncConfig
+
+result = session.start_channel_sync("TO.PARTNER")
+
+match result.operation:
+    case SyncOperation.STARTED:
+        print(f"Running after {result.polls} polls")
+    case SyncOperation.STOPPED:
+        print("Stopped")
+    case SyncOperation.RESTARTED:
+        print(f"Restarted in {result.elapsed:.1f}s")
+```
+
+See [Sync Methods](../sync-methods.md) for the full conceptual overview,
+polling behaviour, and the complete list of available methods.
+
+## API reference
 
 ::: pymqrest.sync.SyncConfig
     options:
       members: true
 
-## SyncOperation
-
 ::: pymqrest.sync.SyncOperation
     options:
       members: true
 
-## SyncResult
-
 ::: pymqrest.sync.SyncResult
     options:
       members: true
-
-## MQRESTSyncMixin
 
 ::: pymqrest.sync.MQRESTSyncMixin
     options:

--- a/docs/site/docs/architecture.md
+++ b/docs/site/docs/architecture.md
@@ -110,6 +110,11 @@ session = MQRESTSession(
 )
 ```
 
+## Zero runtime dependencies
+
+The library uses only the Python standard library plus `requests` for HTTP.
+No other runtime dependencies are required.
+
 ## Generated command methods
 
 The 144 command methods in `MQRESTCommandMixin` are generated from
@@ -124,3 +129,13 @@ method:
 
 Queue manager commands (`DISPLAY QMGR`, `DISPLAY QMSTATUS`, etc.)
 have singleton helpers that return `dict | None` instead of a list.
+
+## Ensure pipeline
+
+See [ensure methods](ensure-methods.md) for details on the idempotent
+create-or-update pipeline.
+
+## Sync pipeline
+
+See [sync methods](sync-methods.md) for details on the synchronous
+polling pipeline.

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -17,14 +17,6 @@ and error propagation.
 - **Zero runtime dependencies** — stdlib only
 - **Transport abstraction** for easy testing with mock transports
 
-## Quick links
-
-- [Getting Started](getting-started.md) — Installation and first session
-- [Architecture](architecture.md) — How the library is organized
-- [Mapping Pipeline](mapping-pipeline.md) — Attribute translation details
-- [API Reference](api/index.md) — Class and method documentation
-- [Examples](examples.md) — Practical scripts for common tasks
-
 ## Installation
 
 ```bash

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -71,16 +71,15 @@ nav:
   - Ensure Methods: ensure-methods.md
   - Sync Methods: sync-methods.md
   - Examples: examples.md
-  - AI Engineering: ai-engineering.md
   - API Reference:
       - api/index.md
       - Session: api/session.md
       - Authentication: api/auth.md
       - Commands: api/commands.md
+      - Transport: api/transport.md
+      - Mapping: api/mapping.md
       - Ensure: api/ensure.md
       - Sync: api/sync.md
-      - Mapping: api/mapping.md
-      - Transport: api/transport.md
       - Exceptions: api/exceptions.md
   - Mappings:
       - mappings/index.md
@@ -138,3 +137,4 @@ nav:
       - Generation Scripts: development/generation-scripts.md
       - Namespace Origin: development/namespace-origin.md
       - Release Workflow: development/release-workflow.md
+  - AI Engineering: ai-engineering.md


### PR DESCRIPTION
## Summary

- Enrich all 5 API reference pages (session, commands, ensure, sync, mapping) with overviews, code examples, inline type definitions, and structured tables to match Java/Go quality
- Add code examples throughout mapping-pipeline.md (intro, request flow, response flow, strict/lenient, opting out)
- Restructure API index with grouped sections (Core, Authentication, Mapping, Exceptions, Patterns)
- Standardize nav ordering to match Java/Go
- Add "Zero runtime dependencies" section and ensure/sync pipeline links to architecture.md
- Remove Quick Links from home page

## Test plan

- [x] `mkdocs build --strict` passes
- Docs-only: tests skipped

Fixes #258
Ref wphillipmoore/mq-rest-admin-common#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>