### PR TITLE
fix: run mike from repo root so snippet base_path resolves in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,10 +58,9 @@ jobs:
           fi
 
       - name: Deploy docs
-        working-directory: docs/site
         run: |
           if [ -n "${{ steps.version.outputs.alias }}" ]; then
-            uv run mike deploy --push --update-aliases ${{ steps.version.outputs.version }} ${{ steps.version.outputs.alias }}
+            uv run mike deploy -F docs/site/mkdocs.yml --push --update-aliases ${{ steps.version.outputs.version }} ${{ steps.version.outputs.alias }}
           else
-            uv run mike deploy --push ${{ steps.version.outputs.version }}
+            uv run mike deploy -F docs/site/mkdocs.yml --push ${{ steps.version.outputs.version }}
           fi


### PR DESCRIPTION
## Summary

- Remove `working-directory: docs/site` from mike deploy step and pass `-F docs/site/mkdocs.yml` instead, so CWD matches the `base_path` entries in mkdocs.yml

Ref wphillipmoore/mq-rest-admin-common#32

## Test plan

- [ ] Docs workflow succeeds and fragment includes render on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)