### PR TITLE
docs: add quality gates documentation page

### DIFF
--- a/docs/site/docs/development/quality-gates.md
+++ b/docs/site/docs/development/quality-gates.md
@@ -1,0 +1,23 @@
+# Quality gates
+
+--8<-- "development/quality-gates.md"
+
+## Python-specific validation
+
+The Python validation pipeline runs via a local validation script:
+
+```bash
+scripts/dev/validate_local.py
+```
+
+This executes:
+
+1. **ruff check** — Lint with all rule categories enabled
+2. **ruff format** — Formatting check
+3. **mypy** — Strict type checking (`src/`)
+4. **ty** — Additional type checking (`src/`)
+5. **pytest** — Unit tests with 100% line and branch coverage enforcement
+6. **pip-audit** — Dependency vulnerability scanning
+7. **uv lock --check** — Lock file synchronization verification
+
+The CI matrix tests against Python 3.12, 3.13, and 3.14.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
       - Developer Setup: development/developer-setup.md
       - Contributing: development/contributing.md
       - Local MQ Container: development/local-mq-container.md
+      - Quality Gates: development/quality-gates.md
       - Generation Scripts: development/generation-scripts.md
       - Namespace Origin: development/namespace-origin.md
       - Release Workflow: development/release-workflow.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add quality gates page to the docs site under Development, including the shared fragment from mq-rest-admin-common
- Append Python-specific validation pipeline details (ruff, mypy, ty, pytest, pip-audit, uv lock check)

## Issue Linkage

- Fixes #269

## Testing

- `mkdocs build -f docs/site/mkdocs.yml --strict` passes
- Docs-only: tests skipped
- Files changed: `docs/site/docs/development/quality-gates.md`, `docs/site/mkdocs.yml`

## Notes

- Shared content pulled from `mq-rest-admin-common` via `--8<-- "development/quality-gates.md"`