### PR TITLE
docs: remove Python-specific design choices and beta status from rationale

### DIFF
--- a/docs/site/docs/design/rationale.md
+++ b/docs/site/docs/design/rationale.md
@@ -1,24 +1,3 @@
 # Design Rationale
 
 --8<-- "design/rationale.md"
-
-## Python-specific design choices
-
-### Return type annotations
-
-**DISPLAY commands** return `list[dict[str, object]]`. An empty list
-means no objects matched -- this is not an error. The caller can iterate
-without checking for `None`.
-
-**Queue manager singletons** (`display_qmgr`, `display_qmstatus`, etc.)
-return `dict[str, object] | None`. These commands always return zero or
-one result, so a list would be misleading.
-
-**Non-DISPLAY commands** (`DEFINE`, `DELETE`, `ALTER`, etc.) return
-`None` on success and raise `MQRESTCommandError` on failure.
-
-### Beta status
-
-`pymqrest` is in beta. The API surface, mapping tables, and return
-shapes are stable but may evolve. The project builds on an approach to
-MQ administration tooling that dates back over 25 years.


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the Python-specific design choices section (return type annotations) and beta status section from the design rationale page
- The page now includes only the shared fragment from mq-rest-admin-common

## Issue Linkage

- Fixes #272

## Testing

- mkdocs build -f docs/site/mkdocs.yml --strict passes
- Docs-only: tests skipped
- Files changed: docs/site/docs/design/rationale.md

## Notes

- Return type annotations are covered in the API reference documentation
- Beta status no longer applicable