### PR TITLE
fix: rename integration-test job to integration-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,8 +245,8 @@ jobs:
         with:
           language: python
 
-  integration-test:
-    name: integration-test
+  integration-tests:
+    name: integration-tests
     runs-on: ubuntu-latest
     needs: docs-only
     if: needs.docs-only.outputs.docs-only != 'true'


### PR DESCRIPTION
## Summary

- Rename `integration-test` CI job to `integration-tests` (plural) to match the CI gates ruleset required check name

Fixes #281

## Test plan

- [ ] The `integration-tests` required check should now appear and pass on PRs

Docs-only: tests skipped

Files changed: `.github/workflows/ci.yml`
