### PR TITLE
fix: remove PR_BUMP_TOKEN and add issue linkage to version bump PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -161,10 +161,8 @@ jobs:
       - name: Create version bump PR
         if: steps.bump_check.outputs.needed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PR_BUMP_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git remote set-url origin \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git checkout -b "${{ steps.next_version.outputs.branch }}" origin/develop
           git merge origin/main --no-edit
 
@@ -191,22 +189,35 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.next_version.outputs.version }}"
           git push origin "${{ steps.next_version.outputs.branch }}"
 
-          gh pr create \
+          pr_url=$(gh pr create \
             --base develop \
             --head "${{ steps.next_version.outputs.branch }}" \
             --title "chore: bump version to ${{ steps.next_version.outputs.version }}" \
-            --body "$(cat <<'EOF'
-          Automated patch version bump after publishing ${{ steps.version.outputs.version }}.
+            --body "Automated patch version bump after publishing ${{ steps.version.outputs.version }}.
 
-          This merges `main` back into `develop` to pick up the changelog and any
+          This merges \`main\` back into \`develop\` to pick up the changelog and any
           other release-branch artifacts, then sets the working version to the next
           expected patch release. Change this to a minor or major bump if the next
           release warrants it.
 
           Dependencies are refreshed to their latest compatible versions
-          via `uv lock --upgrade`.
-          EOF
-          )"
+          via \`uv lock --upgrade\`.")
+
+          pr_number="${pr_url##*/}"
+          gh pr edit "$pr_number" --body "Automated patch version bump after publishing ${{ steps.version.outputs.version }}.
+
+          This merges \`main\` back into \`develop\` to pick up the changelog and any
+          other release-branch artifacts, then sets the working version to the next
+          expected patch release. Change this to a minor or major bump if the next
+          release warrants it.
+
+          Dependencies are refreshed to their latest compatible versions
+          via \`uv lock --upgrade\`.
+
+          Ref #${pr_number}"
+
+          gh pr close "$pr_number"
+          gh pr reopen "$pr_number"
 
           gh pr merge \
             --auto --merge --delete-branch \


### PR DESCRIPTION
## Summary

- Remove `PR_BUMP_TOKEN` secret reference from the version bump step, using `github.token` directly
- Remove the `git remote set-url origin` line that configured token-based auth (unnecessary with `github.token`)
- After creating the version bump PR, capture the URL, extract the PR number, edit the body to include `Ref #N` for issue linkage, close/reopen to trigger notifications, then enable auto-merge

## Motivation

The `PR_BUMP_TOKEN` was a workaround for triggering CI on bot-created PRs. The close/reopen cycle achieves the same goal using only the default `github.token`, eliminating the need for a separate PAT secret.

Ref #66

## Test plan

- [ ] Verify the publish workflow YAML is valid
- [ ] Trigger a publish (or simulate) to confirm the version bump PR is created correctly
- [ ] Confirm the PR body includes the self-referencing `Ref #N` link
- [ ] Confirm the close/reopen cycle triggers expected notification workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
