### PR TITLE
fix: move SBOM generation after PyPI publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,16 +80,16 @@ jobs:
         with:
           subject-path: "dist/*"
 
+      - name: Publish to PyPI
+        if: steps.pypi_check.outputs.status == 'not_found'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
       - name: Generate SBOM
         if: steps.pypi_check.outputs.status == 'not_found'
         uses: wphillipmoore/standard-actions/actions/security/trivy@develop
         with:
           scan-type: sbom
           output-file: dist/pymqrest-${{ steps.version.outputs.version }}.cdx.json
-
-      - name: Publish to PyPI
-        if: steps.pypi_check.outputs.status == 'not_found'
-        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Configure git identity
         if: steps.tag_check.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

- Moves the SBOM generation step after the PyPI publish step in the publish workflow
- The `.cdx.json` file in `dist/` was causing `pypa/gh-action-pypi-publish` to reject it as an unknown distribution format
- SBOM is still generated before the GitHub Release step so it is included in release assets

Ref #282

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Re-run publish workflow after merge to confirm PyPI upload succeeds