### PR TITLE
style: fix ruff lint errors in prepare_release.py

### DIFF
--- a/scripts/dev/prepare_release.py
+++ b/scripts/dev/prepare_release.py
@@ -189,18 +189,18 @@ def create_pr(version: str, issue: int) -> str:
     """Create a PR to main and return the PR URL."""
     print("Creating pull request to main...")
     title = f"release: {version}"
-    body = (
-        f"## Summary\n\n"
-        f"Release {version}\n\n"
-        f"Ref #{issue}\n\n"
-        f"Generated with `prepare_release.py`\n"
-    )
+    body = f"## Summary\n\nRelease {version}\n\nRef #{issue}\n\nGenerated with `prepare_release.py`\n"
     result = subprocess.run(  # noqa: S603
         (
-            "gh", "pr", "create",
-            "--base", "main",
-            "--title", title,
-            "--body", body,
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            "main",
+            "--title",
+            title,
+            "--body",
+            body,
         ),
         check=True,
         text=True,


### PR DESCRIPTION
## Summary
- Fix ruff I001 (import sorting), PTH201 (explicit current directory), and ruff format errors in prepare_release.py
- Follow-up to #286 which synced the canonical version

Ref #285

## Test plan
- [ ] CI ruff check and ruff format should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
