### PR TITLE
feat: use GitHub App token for bump PR to trigger CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,10 +158,18 @@ jobs:
             echo "needed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate app token for bump PR
+        if: steps.bump_check.outputs.needed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create version bump PR
         if: steps.bump_check.outputs.needed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git checkout -b "${{ steps.next_version.outputs.branch }}" origin/develop
           git merge origin/main --no-edit


### PR DESCRIPTION
## Summary

- Replace `GITHUB_TOKEN` with a GitHub App installation token in the publish workflow's bump PR step
- PRs created by `GITHUB_TOKEN` do not trigger workflow runs (GitHub security limitation); using an App token resolves this
- Adds `actions/create-github-app-token@v1` step gated on the same `bump_check.outputs.needed` condition

Fixes #299

See wphillipmoore/standards-and-conventions#196 for the tracking issue.

## Test plan

- [ ] Verify publish workflow syntax is valid
- [ ] Confirm `APP_ID` and `APP_PRIVATE_KEY` secrets are configured in repository settings
- [ ] Trigger a publish and verify the bump PR is created and CI runs on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
