### PR TITLE
docs: rename mq-dev-environment references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
         run: uv sync --frozen --group dev
 
       - name: Setup MQ environment
-        uses: wphillipmoore/mq-dev-environment/.github/actions/setup-mq@main
+        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           project-name: pymqrest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,13 +140,13 @@ The `publish.yml` workflow triggers on push to `main` and publishes to PyPI via 
 ### Local MQ Container
 
 The MQ development environment is owned by the
-[mq-dev-environment](https://github.com/wphillipmoore/mq-dev-environment)
+[mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment)
 repository. Clone it as a sibling directory before running lifecycle
 scripts:
 
 ```bash
 # Prerequisite (one-time)
-git clone https://github.com/wphillipmoore/mq-dev-environment.git ../mq-dev-environment
+git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
 
 # Start the containerized MQ queue managers
 ./scripts/dev/mq_start.sh
@@ -165,7 +165,7 @@ git clone https://github.com/wphillipmoore/mq-dev-environment.git ../mq-dev-envi
 ```
 
 The lifecycle scripts are thin wrappers that delegate to
-`../mq-dev-environment`. Override the path with `MQ_DEV_ENV_PATH`.
+`../mq-rest-admin-dev-environment`. Override the path with `MQ_DEV_ENV_PATH`.
 
 Container details:
 - Queue managers: `QM1` and `QM2`

--- a/docs/mq-container-local-dev.md
+++ b/docs/mq-container-local-dev.md
@@ -21,23 +21,23 @@ real command responses.
 
 ## Files
 
-- `scripts/dev/mq_start.sh` — wrapper delegating to `mq-dev-environment`
-- `scripts/dev/mq_stop.sh` — wrapper delegating to `mq-dev-environment`
-- `scripts/dev/mq_reset.sh` — wrapper delegating to `mq-dev-environment`
-- `scripts/dev/mq_seed.sh` — wrapper delegating to `mq-dev-environment`
-- `scripts/dev/mq_verify.sh` — wrapper delegating to `mq-dev-environment`
+- `scripts/dev/mq_start.sh` — wrapper delegating to `mq-rest-admin-dev-environment`
+- `scripts/dev/mq_stop.sh` — wrapper delegating to `mq-rest-admin-dev-environment`
+- `scripts/dev/mq_reset.sh` — wrapper delegating to `mq-rest-admin-dev-environment`
+- `scripts/dev/mq_seed.sh` — wrapper delegating to `mq-rest-admin-dev-environment`
+- `scripts/dev/mq_verify.sh` — wrapper delegating to `mq-rest-admin-dev-environment`
 
 Docker Compose, MQSC seed files, and web server configuration are owned
 by the
-[mq-dev-environment](https://github.com/wphillipmoore/mq-dev-environment)
+[mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment)
 repository.
 
 ## Prerequisites
 
 - Docker Desktop or compatible Docker Engine.
 - IBM MQ container image access (license acceptance required).
-- The `mq-dev-environment` repository cloned as a sibling directory
-  (`../mq-dev-environment`), or set `MQ_DEV_ENV_PATH` to its location.
+- The `mq-rest-admin-dev-environment` repository cloned as a sibling directory
+  (`../mq-rest-admin-dev-environment`), or set `MQ_DEV_ENV_PATH` to its location.
 
 ## Configuration
 
@@ -184,7 +184,7 @@ volume):
 - If the REST API is not reachable from the host, run:
 
   ```bash
-  docker compose -f ../mq-dev-environment/config/docker-compose.yml exec -T qm1 \
+  docker compose -f ../mq-rest-admin-dev-environment/config/docker-compose.yml exec -T qm1 \
     setmqweb properties -k httpHost -v "*"
   ```
 

--- a/docs/site/docs/development/developer-setup.md
+++ b/docs/site/docs/development/developer-setup.md
@@ -27,7 +27,7 @@ pymqrest depends on two sibling repositories:
 | --- | --- |
 | [pymqrest](https://github.com/wphillipmoore/mq-rest-admin-python) | This project |
 | [standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions) | Canonical project standards (referenced by `AGENTS.md` and git hooks) |
-| [mq-dev-environment](https://github.com/wphillipmoore/mq-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
+| [mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment) | Dockerized MQ test infrastructure (local and CI) |
 
 ## Recommended directory layout
 
@@ -37,14 +37,14 @@ Clone all three repositories as siblings:
 ~/dev/
 ├── mq-rest-admin-python/
 ├── standards-and-conventions/
-└── mq-dev-environment/
+└── mq-rest-admin-dev-environment/
 ```
 
 ```bash
 cd ~/dev
 git clone https://github.com/wphillipmoore/mq-rest-admin-python.git
 git clone https://github.com/wphillipmoore/standards-and-conventions.git
-git clone https://github.com/wphillipmoore/mq-dev-environment.git
+git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git
 ```
 
 ## Initial setup
@@ -114,7 +114,7 @@ validation. The pipeline includes:
 
 - **Unit tests** on Python 3.12, 3.13, and 3.14
 - **Integration tests** against real MQ queue managers via the shared
-  `wphillipmoore/mq-dev-environment/.github/actions/setup-mq` action
+  `wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq` action
 - **Standards compliance** (ruff, mypy, ty, markdown lint, commit
   messages, repository profile)
 - **Dependency audit** (`pip-audit`)

--- a/scripts/dev/mq_reset.sh
+++ b/scripts/dev/mq_reset.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi

--- a/scripts/dev/mq_seed.sh
+++ b/scripts/dev/mq_seed.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi

--- a/scripts/dev/mq_start.sh
+++ b/scripts/dev/mq_start.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi

--- a/scripts/dev/mq_stop.sh
+++ b/scripts/dev/mq_stop.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi

--- a/scripts/dev/mq_verify.sh
+++ b/scripts/dev/mq_verify.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-dev-environment}"
+mq_dev_env="${MQ_DEV_ENV_PATH:-${repo_root}/../mq-rest-admin-dev-environment}"
 
 if [ ! -d "$mq_dev_env" ]; then
-  echo "mq-dev-environment not found at: $mq_dev_env" >&2
+  echo "mq-rest-admin-dev-environment not found at: $mq_dev_env" >&2
   echo "Clone it as a sibling directory or set MQ_DEV_ENV_PATH." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Rename all `mq-dev-environment` references to `mq-rest-admin-dev-environment`
- Phase 1, Step 4 of the repository rename plan
- Historical CHANGELOG.md entry left as-is

## Issue Linkage

- Ref wphillipmoore/mq-dev-environment#14
- Work is not complete until the issue is closed.

## Testing

- markdownlint

Docs-only: tests skipped

Files changed:
- `.github/workflows/ci.yml` (1 reference — `uses:` action path)
- `CLAUDE.md` (3 references — link, clone command, default path)
- `docs/mq-container-local-dev.md` (9 references — file list, link, prerequisites, troubleshooting)
- `docs/site/docs/development/developer-setup.md` (4 references — table link, directory layout, clone command, CI action reference)
- `scripts/dev/mq_start.sh` (2 references — default path, error message)
- `scripts/dev/mq_stop.sh` (2 references)
- `scripts/dev/mq_reset.sh` (2 references)
- `scripts/dev/mq_seed.sh` (2 references)
- `scripts/dev/mq_verify.sh` (2 references)

## Notes

- Pre-rename PR per the execution plan. integration-tests CI gate temporarily removed from rulesets to allow merging before the actual rename (Phase 2).