### PR TITLE
refactor(ci): use shared composite actions for publish and release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,26 +108,10 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        run: |
-          git fetch origin main --depth=1
-          main_version=$(python3 -c "
-          import tomllib, subprocess
-          text = subprocess.run(
-              ['git', 'show', 'origin/main:pyproject.toml'],
-              capture_output=True, text=True, check=True
-          ).stdout
-          print(tomllib.loads(text)['project']['version'])
-          ")
-          head_version=$(python3 -c "
-          import tomllib
-          from pathlib import Path
-          print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])
-          ")
-          if [ "$main_version" = "$head_version" ]; then
-            echo "FAIL: PR version ($head_version) must differ from main ($main_version)."
-            exit 1
-          fi
-          echo "OK: PR version ($head_version) differs from main ($main_version)."
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        with:
+          head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
+          main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"
 
   test-and-validate:
     name: test-and-validate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,142 +91,44 @@ jobs:
           scan-type: sbom
           output-file: dist/pymqrest-${{ steps.version.outputs.version }}.cdx.json
 
-      - name: Configure git identity
+      - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
+        with:
+          version: ${{ steps.version.outputs.version }}
+          release-title: pymqrest
+          release-notes: |
+            ## Installation
 
-      - name: Create git tag
-        if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          git tag -a "${{ steps.version.outputs.tag }}" \
-            -m "Release ${{ steps.version.outputs.version }}"
-          git push origin "${{ steps.version.outputs.tag }}"
+            ```bash
+            pip install pymqrest==${{ steps.version.outputs.version }}
+            ```
 
-      - name: Tag develop for changelog boundaries
-        if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          git fetch origin develop
-          git tag "develop-${{ steps.version.outputs.tag }}" origin/develop
-          git push origin "develop-${{ steps.version.outputs.tag }}"
+            ## Links
 
-      - name: Create GitHub Release
-        if: steps.tag_check.outputs.exists == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --title "pymqrest ${{ steps.version.outputs.version }}" \
-            --notes "$(cat <<'EOF'
-          ## Installation
-
-          ```bash
-          pip install pymqrest==${{ steps.version.outputs.version }}
-          ```
-
-          ## Links
-
-          - [PyPI](https://pypi.org/project/pymqrest/${{ steps.version.outputs.version }}/)
-          - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-python/)
-          EOF
-          )" \
-            dist/*
-
-      - name: Compute next patch version
-        id: next_version
-        run: |
-          next=$(python3 -c "
-          v = '${{ steps.version.outputs.version }}'.split('.')
-          v[2] = str(int(v[2]) + 1)
-          print('.'.join(v))
-          ")
-          echo "version=$next" >> "$GITHUB_OUTPUT"
-          echo "branch=chore/bump-version-$next" >> "$GITHUB_OUTPUT"
-
-      - name: Check if develop already has next version
-        id: bump_check
-        run: |
-          git fetch origin develop
-          current=$(git show origin/develop:pyproject.toml | python3 -c "
-          import sys, tomllib
-          print(tomllib.loads(sys.stdin.read())['project']['version'])
-          ")
-          if [ "$current" = "${{ steps.next_version.outputs.version }}" ]; then
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "needed=true" >> "$GITHUB_OUTPUT"
-          fi
+            - [PyPI](https://pypi.org/project/pymqrest/${{ steps.version.outputs.version }}/)
+            - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-python/)
+          release-artifacts: dist/*
 
       - name: Generate app token for bump PR
-        if: steps.bump_check.outputs.needed == 'true'
+        if: steps.tag_check.outputs.exists == 'false'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Create version bump PR
-        if: steps.bump_check.outputs.needed == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git checkout -b "${{ steps.next_version.outputs.branch }}" origin/develop
-          git merge origin/main --no-edit
-
-          python3 -c "
-          from pathlib import Path
-          import re
-          p = Path('pyproject.toml')
-          content = p.read_text()
-          content = re.sub(
-              r'^(version\s*=\s*\").*(\"\s*)$',
-              r'\g<1>${{ steps.next_version.outputs.version }}\2',
-              content,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          p.write_text(content)
-          "
-
-          uv lock --upgrade
-          uv export --no-hashes -o requirements.txt
-          uv export --no-hashes --group dev -o requirements-dev.txt
-
-          git add pyproject.toml uv.lock requirements.txt requirements-dev.txt
-          git commit -m "chore: bump version to ${{ steps.next_version.outputs.version }}"
-          git push origin "${{ steps.next_version.outputs.branch }}"
-
-          pr_url=$(gh pr create \
-            --base develop \
-            --head "${{ steps.next_version.outputs.branch }}" \
-            --title "chore: bump version to ${{ steps.next_version.outputs.version }}" \
-            --body "Automated patch version bump after publishing ${{ steps.version.outputs.version }}.
-
-          This merges \`main\` back into \`develop\` to pick up the changelog and any
-          other release-branch artifacts, then sets the working version to the next
-          expected patch release. Change this to a minor or major bump if the next
-          release warrants it.
-
-          Dependencies are refreshed to their latest compatible versions
-          via \`uv lock --upgrade\`.")
-
-          pr_number="${pr_url##*/}"
-          gh pr edit "$pr_number" --body "Automated patch version bump after publishing ${{ steps.version.outputs.version }}.
-
-          This merges \`main\` back into \`develop\` to pick up the changelog and any
-          other release-branch artifacts, then sets the working version to the next
-          expected patch release. Change this to a minor or major bump if the next
-          release warrants it.
-
-          Dependencies are refreshed to their latest compatible versions
-          via \`uv lock --upgrade\`.
-
-          Ref #${pr_number}"
-
-          gh pr close "$pr_number"
-          gh pr reopen "$pr_number"
-
-          gh pr merge \
-            --auto --merge --delete-branch \
-            "${{ steps.next_version.outputs.branch }}"
+      - name: Version bump PR
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
+        with:
+          current-version: ${{ steps.version.outputs.version }}
+          version-file: pyproject.toml
+          version-regex: '^(version\s*=\s*\").*(\"\s*)$'
+          version-replacement: '\g<1>{version}\2'
+          version-regex-multiline: "true"
+          develop-version-command: python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"
+          post-bump-command: uv lock --upgrade && uv export --no-hashes -o requirements.txt && uv export --no-hashes --group dev -o requirements-dev.txt
+          extra-files: uv.lock requirements.txt requirements-dev.txt
+          app-token: ${{ steps.app-token.outputs.token }}
+          pr-body-extra: Dependencies are refreshed to their latest compatible versions via `uv lock --upgrade`.


### PR DESCRIPTION
# Pull Request

## Summary

- Use shared composite actions for publish tag/release, version bump PR, and version divergence gate

## Issue Linkage

- Fixes #332

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -