### PR TITLE
chore: update CI action pins and uv to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       docs-only: ${{ steps.detect.outputs.docs-only }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect docs-only changes
         id: detect
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: wphillipmoore/standard-actions/actions/python/setup@develop
@@ -86,13 +86,13 @@ jobs:
 
       - name: Checkout code
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.14
         if: github.event_name == 'pull_request'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -128,7 +128,7 @@ jobs:
 
       - name: Checkout code
         if: needs.docs-only.outputs.docs-only != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Fetch base branch for version checks
         if: github.event_name == 'pull_request' && needs.docs-only.outputs.docs-only != 'true'
@@ -190,7 +190,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run CodeQL analysis
         uses: wphillipmoore/standard-actions/actions/security/codeql@develop
@@ -206,7 +206,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scan
         uses: wphillipmoore/standard-actions/actions/security/trivy@develop
@@ -222,7 +222,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Semgrep SAST scan
         uses: wphillipmoore/standard-actions/actions/security/semgrep@develop
@@ -236,7 +236,7 @@ jobs:
     if: needs.docs-only.outputs.docs-only != 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: wphillipmoore/standard-actions/actions/python/setup@develop

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install uv
         if: steps.pypi_check.outputs.status == 'not_found'
-        run: python3 -m pip install uv==0.9.26
+        run: python3 -m pip install uv==0.10.4
 
       - name: Build sdist and wheel
         if: steps.pypi_check.outputs.status == 'not_found'
@@ -76,7 +76,7 @@ jobs:
 
       - name: Attest build provenance
         if: steps.pypi_check.outputs.status == 'not_found'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: "dist/*"
 
@@ -113,7 +113,7 @@ jobs:
       - name: Generate app token for bump PR
         if: steps.tag_check.outputs.exists == 'false'
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ The include directives at the top of this file load the full repository standard
 
 **Python Invocation**: Always use `uv run python3 <script>`
 
-**Tooling**: `uv` version `0.9.26`
+**Tooling**: `uv` version `0.10.4`
 
 **Code Quality**: Ruff (all rules), mypy (strict), 100% test coverage, Python 3.14+
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -51,7 +51,7 @@
 
 Required for daily workflow:
 
-- `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`)
+- `uv` `0.10.4` (install with `python3 -m pip install uv==0.10.4`)
 - `markdownlint` (required for docs validation and PR pre-submission)
 
 Required for integration testing:

--- a/docs/site/docs/development/developer-setup.md
+++ b/docs/site/docs/development/developer-setup.md
@@ -8,7 +8,7 @@ locally.
 | Tool | Version | Purpose |
 | --- | --- | --- |
 | Python | 3.12+ | Runtime |
-| `uv` | 0.9.26 | Package and environment management |
+| `uv` | 0.10.4 | Package and environment management |
 | Docker | Latest | Local MQ containers (integration tests) |
 | `markdownlint` | Latest | Docs validation |
 | `git-cliff` | Latest | Changelog generation (releases only) |
@@ -16,7 +16,7 @@ locally.
 Install `uv`:
 
 ```bash
-python3 -m pip install uv==0.9.26
+python3 -m pip install uv==0.10.4
 ```
 
 ## Required repositories

--- a/scripts/dev/validate_venv.py
+++ b/scripts/dev/validate_venv.py
@@ -8,7 +8,7 @@ import subprocess
 from pathlib import Path
 
 REQUIRED_TOOLS: tuple[str, ...] = ("pip-audit", "ruff", "mypy", "ty", "pytest")
-UV_VERSION = "0.9.26"
+UV_VERSION = "0.10.4"
 
 
 def ensure_project_root() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- Update CI action pins and uv tooling for next development cycle after v1.1.8 release

## Issue Linkage

- Ref #334

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -
