### PR TITLE
fix: scope Python linters to src/ and tests/, sync standard-tooling v1.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ pymqrest = ["py.typed", "mapping-data.json"]
 line-length = 120
 target-version = "py312"
 src = ["src", "tests"]
-extend-exclude = ["docs/archive"]
+extend-exclude = ["docs/archive", "scripts"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -89,10 +89,6 @@ docstring-quotes = "double"
     "S101", # Pytest assert style is expected.
     "S105", # Hardcoded test passwords are expected in test fixtures.
     "S106", # Hardcoded test password arguments are expected in test fixtures.
-]
-"scripts/**/*.py" = [
-    "D1",  # Internal tooling scripts do not require docstrings.
-    "T201", # Scripts use print for user-facing output.
 ]
 "examples/**/*.py" = [
     "INP001", # Example scripts are not a package; no __init__.py needed.

--- a/scripts/dev/commit.sh
+++ b/scripts/dev/commit.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 # Commit wrapper that constructs standards-compliant commit messages.
 # Resolves Co-Authored-By identities from docs/repository-standards.md.
 

--- a/scripts/dev/finalize_repo.sh
+++ b/scripts/dev/finalize_repo.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 # Finalize a repository after a PR merge: switch to the target branch,

--- a/scripts/dev/submit-pr.sh
+++ b/scripts/dev/submit-pr.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 # PR submission wrapper that constructs standards-compliant PR bodies.
 # Populates .github/pull_request_template.md programmatically.
 

--- a/scripts/dev/sync-tooling.sh
+++ b/scripts/dev/sync-tooling.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 # sync-tooling.sh — keep local copies of shared scripts in sync with
@@ -110,7 +112,7 @@ if [[ -n "$ref" ]]; then
 else
   # Discover the latest tag without a full clone.
   clone_ref="$(git ls-remote --tags --sort=-v:refname "$TOOLING_REPO" 'v*' \
-    | head -n 1 | sed 's|.*refs/tags/||')"
+    | head -n 1 | sed 's|.*refs/tags/||; s|\^{}$||')"
   if [[ -z "$clone_ref" ]]; then
     echo "ERROR: no tags found in $TOOLING_REPO" >&2
     exit 1

--- a/scripts/dev/validate_local.sh
+++ b/scripts/dev/validate_local.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Canonical source: standard-tooling
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate_local.sh — shared driver for pre-PR local validation.
 #
 # Reads primary_language from docs/repository-standards.md, then runs:

--- a/scripts/dev/validate_local_common.sh
+++ b/scripts/dev/validate_local_common.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Canonical source: standard-tooling
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate_local_common.sh — shared checks run for ALL repos.
 set -euo pipefail
 

--- a/scripts/dev/validate_local_go.sh
+++ b/scripts/dev/validate_local_go.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Canonical source: standard-tooling
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate_local_go.sh — Go-specific local validation checks.
 set -euo pipefail
 

--- a/scripts/dev/validate_local_java.sh
+++ b/scripts/dev/validate_local_java.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Canonical source: standard-tooling
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate_local_java.sh — Java-specific local validation checks.
 set -euo pipefail
 

--- a/scripts/dev/validate_local_python.sh
+++ b/scripts/dev/validate_local_python.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Canonical source: standard-tooling
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 # validate_local_python.sh — Python-specific local validation checks.
 set -euo pipefail
 

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
@@ -62,4 +64,19 @@ if [[ ! "$current_branch" =~ $allowed_regex ]]; then
   echo "ERROR: branch name must use $allowed_display ($current_branch)." >&2
   echo "Rename the branch before committing." >&2
   exit 1
+fi
+
+# Validate issue-number naming for work branches.
+# Format: {type}/{issue}-{description}
+# Exempt: release/* (automated by the publish workflow, no issue association).
+issue_required_regex='^(feature|bugfix|hotfix)/'
+issue_format_regex='^(feature|bugfix|hotfix)/[0-9]+-[a-z0-9][a-z0-9-]*$'
+
+if [[ "$current_branch" =~ $issue_required_regex ]]; then
+  if [[ ! "$current_branch" =~ $issue_format_regex ]]; then
+    echo "ERROR: branch name must include a repo issue number ($current_branch)." >&2
+    echo "Expected format: {type}/{issue}-{description}" >&2
+    echo "Example: feature/42-add-caching" >&2
+    exit 1
+  fi
 fi

--- a/scripts/lint/co-author.sh
+++ b/scripts/lint/co-author.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 commit_message_file="${1:-}"

--- a/scripts/lint/commit-message.sh
+++ b/scripts/lint/commit-message.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 commit_message_file="${1:-}"
@@ -9,6 +11,12 @@ if [[ -z "$commit_message_file" || ! -f "$commit_message_file" ]]; then
 fi
 
 subject_line="$(head -n 1 "$commit_message_file")"
+
+# Allow merge commits through without conventional commit validation.
+merge_regex='^Merge '
+if [[ "$subject_line" =~ $merge_regex ]]; then
+  exit 0
+fi
 
 conventional_regex='^(feat|fix|docs|style|refactor|test|chore|ci|build)(\([^\)]+\))?: .+'
 

--- a/scripts/lint/commit-messages.sh
+++ b/scripts/lint/commit-messages.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 base_ref="${1:-}"

--- a/scripts/lint/markdown-standards.sh
+++ b/scripts/lint/markdown-standards.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 # Collect standard docs (structural checks + markdownlint).

--- a/scripts/lint/pr-issue-linkage.sh
+++ b/scripts/lint/pr-issue-linkage.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 set -euo pipefail
 
 if [[ -z "${GITHUB_EVENT_PATH:-}" ]]; then

--- a/scripts/lint/repo-profile.sh
+++ b/scripts/lint/repo-profile.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+# Managed by standard-tooling — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling
 # shellcheck disable=SC2034
 # Variables are read via indirect expansion (${!key}).
-# Canonical source: standard-tooling
 set -euo pipefail
 
 profile_file="docs/repository-standards.md"


### PR DESCRIPTION
# Pull Request

## Summary

- Scope Python linters to src/ and tests/, sync standard-tooling v1.1.4

## Issue Linkage

- Fixes #351

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -
