### PR TITLE
fix: update add-to-project action to v1.0.2

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,7 +8,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/users/wphillipmoore/projects/3
           github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Summary

- Update add-to-project action from removed v1 tag to v1.0.2

## Issue Linkage

- Fixes #356

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -
