### PR TITLE
chore(ci): standardize CI and publish workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Validate standards
         uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
         with:
-          commit-cutoff-sha: "df45093c260def11f409dc4f3ba86e91ec444797"
+          commit-cutoff-sha: "df45093"
 
   dependency-audit:
     name: "ci: dependency-audit"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish release
 
 on:
   push:


### PR DESCRIPTION
# Pull Request

## Summary

- Standardize CI and publish workflow files

## Issue Linkage

- Fixes #358

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -
