### PR TITLE
ci: add SonarCloud quality analysis to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,50 @@ jobs:
         with:
           language: python
 
+  sonarcloud:
+    name: "quality: sonarcloud"
+    runs-on: ubuntu-latest
+    needs: docs-only
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping SonarCloud."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: wphillipmoore/standard-actions/actions/python/setup@develop
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: uv sync --frozen --group dev
+
+      - name: Run tests with coverage
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: |
+          uv run pytest \
+            --cov=pymqrest \
+            --cov-report=xml \
+            --cov-branch
+
+      - name: Run SonarCloud scan
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: wphillipmoore/standard-actions/actions/quality/sonarcloud@develop
+        with:
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          organization: wphillipmoore
+          project-key: wphillipmoore_mq-rest-admin-python
+          sources: "src"
+          tests: "tests"
+          coverage-report: "coverage.xml"
+
   integration-tests:
     name: "test: integration"
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Summary

- Add SonarCloud quality analysis job to CI workflow using the new composite action from standard-actions

## Issue Linkage

- Fixes #365

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -