### PR TITLE
ci: add Code Climate (Qlty) coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,46 @@ jobs:
           tests: "tests"
           coverage-report: "coverage.xml"
 
+  codeclimate:
+    name: "quality: codeclimate"
+    runs-on: ubuntu-latest
+    needs: docs-only
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping Code Climate."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: wphillipmoore/standard-actions/actions/python/setup@develop
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: uv sync --frozen --group dev
+
+      - name: Run tests with coverage
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: |
+          uv run pytest \
+            --cov=pymqrest \
+            --cov-report=lcov \
+            --cov-branch
+
+      - name: Upload coverage to Qlty Cloud
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: wphillipmoore/standard-actions/actions/quality/codeclimate@develop
+        with:
+          files: "coverage.lcov"
+
   integration-tests:
     name: "test: integration"
     runs-on: ubuntu-latest

--- a/.github/workflows/codeclimate.yml
+++ b/.github/workflows/codeclimate.yml
@@ -1,0 +1,42 @@
+name: Code Climate
+
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: codeclimate
+  cancel-in-progress: false
+
+jobs:
+  codeclimate:
+    name: "quality: codeclimate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: wphillipmoore/standard-actions/actions/python/setup@develop
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run tests with coverage
+        run: |
+          uv run pytest \
+            --cov=pymqrest \
+            --cov-report=lcov \
+            --cov-branch
+
+      - name: Upload coverage to Qlty Cloud
+        uses: wphillipmoore/standard-actions/actions/quality/codeclimate@develop
+        with:
+          files: "coverage.lcov"


### PR DESCRIPTION
# Pull Request

## Summary

- Add codeclimate job to ci.yml and codeclimate.yml post-merge workflow for Qlty Cloud coverage upload via OIDC

## Issue Linkage

- Fixes #368

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -