### PR TITLE
feat(ci): run integration tests with same Python version matrix as unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,10 @@ jobs:
     name: "test: integration"
     runs-on: ubuntu-latest
     needs: docs-only
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+
     steps:
       - name: Docs-only short-circuit
         if: needs.docs-only.outputs.docs-only == 'true'
@@ -337,7 +341,7 @@ jobs:
         if: needs.docs-only.outputs.docs-only != 'true'
         uses: wphillipmoore/standard-actions/actions/python/setup@develop
         with:
-          python-version: "3.14"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         if: needs.docs-only.outputs.docs-only != 'true'


### PR DESCRIPTION
# Pull Request

## Summary

- Run integration tests with the same Python version matrix (3.12, 3.13, 3.14) as unit tests for consistent coverage

## Issue Linkage

- Ref #85

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -