### PR TITLE
ci: assign unique REST API ports per integration test matrix entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
           files: "coverage.lcov"
 
   integration-tests:
-    name: "test: integration"
+    name: "test: integration (${{ matrix.python-version }})"
     runs-on: ubuntu-latest
     needs: docs-only
     strategy:


### PR DESCRIPTION
# Pull Request

## Summary

- Assign unique QM1/QM2 REST API ports (9447-9452) per Python version matrix entry so integration test containers can coexist in parallel

## Issue Linkage

- Fixes #371

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -