### PR TITLE
chore(ruff): configure PLR0913 max-args and remove inline noqa suppressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ docstring-quotes = "double"
     "T201",   # Example scripts use print for user-facing output.
 ]
 
+[tool.ruff.lint.pylint]
+max-args = 7
+
 [tool.ruff.format]
 quote-style = "double"
 

--- a/src/pymqrest/auth.py
+++ b/src/pymqrest/auth.py
@@ -72,7 +72,7 @@ Credentials = BasicAuth | LTPAAuth | CertificateAuth
 """Type alias for the supported credential types."""
 
 
-def _perform_ltpa_login(  # noqa: PLR0913
+def _perform_ltpa_login(
     transport: MQRESTTransport,
     rest_base_url: str,
     credentials: LTPAAuth,

--- a/src/pymqrest/commands.py
+++ b/src/pymqrest/commands.py
@@ -20,7 +20,7 @@ class MQRESTCommandMixin:
     for the full IBM MQ 9.4 command reference.
     """
 
-    def _mqsc_command(  # noqa: PLR0913
+    def _mqsc_command(
         self,
         *,
         command: str,

--- a/src/pymqrest/ensure.py
+++ b/src/pymqrest/ensure.py
@@ -52,7 +52,7 @@ class MQRESTEnsureMixin:
     ``ALTDATE``/``ALTTIME`` for unchanged objects.
     """
 
-    def _mqsc_command(  # noqa: PLR0913
+    def _mqsc_command(
         self,
         *,
         command: str,

--- a/src/pymqrest/mapping.py
+++ b/src/pymqrest/mapping.py
@@ -374,7 +374,7 @@ def _handle_unknown_qualifier_list(
     raise MappingError(issues)
 
 
-def _map_attributes(  # noqa: PLR0913
+def _map_attributes(
     *,
     qualifier: str,
     attributes: Mapping[str, object],
@@ -398,7 +398,7 @@ def _map_attributes(  # noqa: PLR0913
     return mapped_attributes
 
 
-def _map_attributes_internal(  # noqa: PLR0913
+def _map_attributes_internal(
     *,
     qualifier: str,
     attributes: Mapping[str, object],
@@ -458,7 +458,7 @@ def _map_attributes_internal(  # noqa: PLR0913
     return mapped_attributes, issues
 
 
-def _map_value(  # noqa: PLR0913
+def _map_value(
     *,
     qualifier: str,
     attribute_name: str,
@@ -499,7 +499,7 @@ def _map_value(  # noqa: PLR0913
     return attribute_value, []
 
 
-def _map_value_list(  # noqa: PLR0913
+def _map_value_list(
     *,
     qualifier: str,
     attribute_name: str,

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -308,7 +308,7 @@ class MQRESTSession(MQRESTSyncMixin, MQRESTEnsureMixin, MQRESTCommandMixin):
         """The gateway queue manager name, or ``None`` for direct access."""
         return self._gateway_qmgr
 
-    def _mqsc_command(  # noqa: PLR0913
+    def _mqsc_command(
         self,
         *,
         command: str,

--- a/src/pymqrest/sync.py
+++ b/src/pymqrest/sync.py
@@ -108,7 +108,7 @@ class MQRESTSyncMixin:
     perform a synchronous stop followed by a synchronous start.
     """
 
-    def _mqsc_command(  # noqa: PLR0913
+    def _mqsc_command(
         self,
         *,
         command: str,


### PR DESCRIPTION
# Pull Request

## Summary

- Configure PLR0913 max-args=7 and remove 7 inline noqa suppressions

## Issue Linkage

- Fixes #381

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -