### PR TITLE
chore: generate retroactive release notes for all existing releases

### DIFF
--- a/cliff-release-notes.toml
+++ b/cliff-release-notes.toml
@@ -11,7 +11,7 @@ body = """{% if version -%}
           {% if commit.body %}
           {{ commit.body | trim }}
           {% endif -%}
-    {% endfor -%}
+    {% endfor %}
 {% endfor %}
 """
 footer = ""

--- a/releases/.markdownlint.json
+++ b/releases/.markdownlint.json
@@ -4,5 +4,8 @@
   "MD013": false,
   "MD024": { "siblings_only": true },
   "MD032": false,
-  "MD041": false
+  "MD033": false,
+  "MD037": false,
+  "MD041": false,
+  "MD050": false
 }

--- a/releases/v0.1.0.md
+++ b/releases/v0.1.0.md
@@ -1,0 +1,336 @@
+
+# Release 0.1.0 (2026-02-10)
+
+## Bug fixes
+
+- **prevent docs-only merge-base failures**
+Ensure the docs-only detector has full history so the diff against the
+base branch succeeds on PR merge refs.
+
+- **make docs-only detection merge-base independent**
+Use the GitHub API file list for pull requests so docs-only detection does
+not rely on git merge-base in Actions.
+
+- **satisfy ruff checks for metadata refresh script**
+- **update include directives**
+Convert include directives to HTML comment form to avoid markdownlint MD018.
+
+- **harden response parameter mapping**
+Handle output-only parameters in response mapping and skip invalid qualifiers.
+
+Update mapping tests for strict/lenient cases.
+
+- **standardize shared MQSC attribute mappings**
+Normalize selected token mappings across qualifiers and refresh conflicts report.
+
+- **standardize additional shared attributes**
+Normalize AMQPKA/CHANNEL/CONNAME/DEFTYPE and related mappings across qualifiers.
+
+- **standardize CFSTRUCT and CLWL mappings**
+Normalize CFSTRUCT/CLWL* and related attribute aliases across qualifiers.
+
+- **correct ClusterWorkloadRank mapping**
+Rename CLWLRANK from ClusterWorkloadTank to ClusterWorkloadRank.
+
+- **standardize DESCR mapping**
+Map DESCR to Description across qualifiers and refresh artifacts.
+
+- **enforce per-qualifier unique mappings**
+Resolve duplicate MQSC mappings via overrides/skips and add a guard test.
+
+- **normalize client/message/user mappings**
+Align CLIENTID/USERID and message delivery/count attributes across qualifiers.
+
+- **standardize identifiers and LIKE mapping**
+Normalize QMID/QMNAME/SUBUSER/LIKE plus filter STATUS/TYPE from conflicts.
+
+- **normalize QMgr and Like mappings**
+Standardize QMID/QMNAME/SUBUSER/LIKE and filter STATUS/TYPE from conflicts.
+
+- **normalize Like and QMgr identifiers**
+Apply Like/QMgr/SubUser standardization and filter STATUS/TYPE from conflicts.
+
+- **clean stgclass Like override**
+Remove stray stgclass overrides from request_key_value_map and regenerate maps.
+
+- **normalize SSLPEER and cfstatus recovery mappings**
+Standardize SSLPEER, MEDIALOG, and cfstatus recovery attributes.
+
+- **normalize cfstatus recovery fields**
+Standardize SSLPEER, MEDIALOG, and cfstatus recovery names.
+
+- **normalize CLWL PCF names (issue #88)**
+- **expand Msg to Message in PCF overrides (issue #87)**
+- **normalize Identifier to Id (issue #86)**
+- **normalize CFStructType override (issue #82)**
+- **remove name parameter from QMGR and CMDSERV command methods (#100)**
+QMGR-level and CMDSERV MQSC commands operate on the local queue manager
+implicitly (identified by REST endpoint URL). The name argument was
+misleading since IBM MQSC syntax does not accept it for these commands.
+
+- **omit responseParameters from non-DISPLAY commands to prevent silent failures (#125)**
+_normalize_response_parameters() unconditionally defaulted to ["all"]
+for all command types. The MQ REST API silently ignores ALTER, DEFINE,
+and DELETE operations when responseParameters is present in the payload,
+returning success without applying changes.
+
+Also handles MQRESTCommandError from DISPLAY of non-existent objects in
+ensure methods (MQ returns reason 2085 instead of an empty result set).
+
+- **configure git identity for annotated tag creation in publish workflow (#143)**
+
+## Documentation
+
+- **align repo docs with standards (#12)**
+* Document metadata milestone and mapping data structures
+
+* feat: add mapping runtime and generator
+
+Add strict mapping helpers with deferred error aggregation, a generator for precompiled mapping data, and initial tests. Add curated mapping inputs, standards registry, and a follow-up plan.
+
+- **align standards entrypoint with repo type**
+Restructure the standards entrypoint to list core and library references.
+
+- **adopt standards include bootstrap**
+- **align standards includes**
+Move repository standards into docs and include them from AGENTS only.
+
+- **require uv run for python commands**
+Clarify that all python invocations must use uv run, and update local validation examples.
+
+- **archive first-pass docs and capture mqsc list (#70)**
+* docs: archive first-pass docs and capture mqsc list
+
+Archived the first-pass mapping artifacts and added the MQSC command list extraction reference files.
+
+- **regroup conflicts report**
+Group collisions by PCF attribute for easier review.
+
+- **note codex command policy workaround**
+Record the temporary branch-cleanup workaround for codex runs.
+
+- **add CLAUDE.md for Claude Code integration (#96)**
+* docs: add CLAUDE.md for Claude Code integration
+
+Adds CLAUDE.md to provide Claude Code-specific guidance that
+complements the existing AGENTS.md include-directive approach.
+
+- Documents dual-file documentation strategy
+- Includes repository standards via include directives
+- Provides prescriptive commands and workflows for /init
+- Explains integration between AGENTS.md and CLAUDE.md
+- Adds best practices for maintaining both files
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+- **document standards compliance gates implementation (#99)**
+- **add Sphinx documentation tree with mapping reference and API docs (#30) (#105)**
+Add a complete Sphinx documentation site using MyST Markdown and the furo
+theme. Includes narrative pages (getting started, architecture, mapping
+pipeline, AI engineering transparency, design rationale), autodoc API
+reference for all public modules, and 48 auto-generated qualifier mapping
+pages showing snake_case to MQSC attribute translations.
+
+- **rework API reference pages for readability (#108)**
+Replace raw automodule dumps with curated pages using targeted
+autoclass/autofunction directives and a hand-written command reference
+table. Ref #30.
+
+- **enrich docstrings for session, mapping, and exception modules (#111)**
+Add Args, Returns, Raises, and Attributes sections to all public
+classes and functions so Sphinx autodoc renders useful API reference
+pages. Ref #30.
+
+- **add docstrings to all MQSC command wrapper methods (#109) (#116)**
+Add a generation script (scripts/dev/generate_commands.py) that
+regenerates the block between BEGIN/END GENERATED MQSC METHODS
+markers in commands.py, embedding docstrings in every generated
+method. Manually add docstrings to the 13 hand-written methods
+and the MQRESTCommandMixin class. Each docstring includes the
+IBM MQ 9.4 MQSC reference URL and Sphinx cross-references to
+qualifier mapping pages where available.
+
+Also adds DISPLAY SYSTEM and SET SYSTEM to MAPPING_DATA commands
+to keep parity with docs/extraction/mqsc-commands.yaml, and
+removes the D1 per-file ignore for commands.py from pyproject.toml
+since all methods now have docstrings.
+
+- **fix autodoc rendering by wrapping directives in eval-rst blocks (#117)**
+MyST-parser cannot interpret the reST output generated by autodoc,
+causing class signatures and attributes to render as illegible nested
+definition lists. Wrapping all autoclass/autofunction directives in
+eval-rst blocks passes content to the reST parser directly.
+
+- **credit both Claude Code and Codex in AI engineering page (#118)**
+Make the AI-assisted engineering page vendor-agnostic and list both
+AI coding agents used in the project development.
+
+- **separate unmapped qualifiers in mapping index, rewrite auth docs (#135)**
+The mapping index now lists only the 39 qualifiers with attribute
+mappings in the main toctree and calls out the 9 unmapped qualifiers
+in a separate prose section with a hidden toctree.  The authentication
+page reorders credential types most-secure-first and adds a new
+"Choosing between LTPA and Basic authentication" section covering
+realistic trade-offs.
+
+- **remove misleading "yet" from unmapped qualifier description (#137)**
+These qualifiers have no attributes to map — the word "yet" implied
+the mappings were incomplete rather than intentionally absent.
+
+- **clarify mapping data is bootstrapped from 9.4 docs, now authoritative in source (#141)**
+
+## Features
+
+- **add mq container tooling and refresh mqsc output metadata**
+- **add MQ REST session framework**
+Introduce MQRESTSession with transport, mapping integration, and initial command wrappers.
+Add unit tests and refresh the API surface docs.
+
+- **switch session transport to requests**
+Replace urllib transport with requests, add runtime and typing dependencies, and build integration tests for display_qmgr/queue/channel.
+
+- **add more MQSC helper methods**
+Add queue manager display helpers and queue define variants; refresh docs/tests.
+
+- **expand MQSC command wrappers**
+Generate wrappers for the full MQSC command list and document the naming scheme.
+
+- **add MQSC qualifier placeholders**
+Populate command->qualifier mappings and expand integration config for new display helpers.
+
+- **support request key/value mappings**
+- **document response parameter macros (issue #84)**
+- **enable strict attribute mapping by default (#98)**
+Change MQRESTSession default from mapping_strict=False to
+mapping_strict=True so unknown attributes raise MappingError
+instead of silently passing through. This surfaces mapping
+gaps early rather than masking them.
+
+- **add WHERE filter support for DISPLAY commands (#101)**
+Add a `where` parameter to all 41 list-returning DISPLAY methods that
+maps filter-keyword names from snake_case to MQSC using the existing
+attribute mapping infrastructure. The WHERE condition string is injected
+into the request parameters as {"WHERE": "mapped_condition"}.
+
+When mapping is disabled, the WHERE string passes through as-is. When
+mapping is enabled in strict mode, unknown filter-keywords raise
+MappingError.
+
+- **flatten nested objects in command response parameters (#103)**
+DISPLAY CONN TYPE(HANDLE) returns a nested objects list within each
+connection parameters. Automatically detect and flatten this pattern
+so each nested item becomes its own dict with shared attributes
+replicated. Empty objects lists produce no output entries.
+
+- **add practical example scripts with multi-QM Docker environment (#104) (#119)**
+Expand the single-QM Docker setup to two queue managers (QM1 + QM2) on a
+shared network, add five practical example scripts exercising real MQ
+administration tasks, and wire up integration tests and Sphinx documentation.
+
+- **add idempotent ensure methods for declarative object management (#75) (#121)**
+Introduce ensure_*() methods that implement a declarative upsert pattern:
+DEFINE when an object does not exist, ALTER only when specified attributes
+differ, and no-op when they already match — preserving ALTDATE/ALTTIME
+for unchanged objects. Each call returns an EnsureResult enum (CREATED,
+UPDATED, UNCHANGED).
+
+- **add ensure_qmgr for idempotent queue manager attribute management (#123)**
+Singleton variant of the ensure pattern — no name parameter, no DEFINE
+path, returns UPDATED or UNCHANGED (never CREATED).  Critical for
+declarative management of statistics, monitoring, events, and logging
+attributes without corrupting ALTDATE/ALTTIME.
+
+- **add LTPA token and mTLS client certificate authentication (#131)**
+Add credential dataclasses (BasicAuth, LTPAAuth, CertificateAuth) to
+support three authentication modes for the IBM MQ REST API. Sessions
+accept a credentials keyword parameter while keeping positional
+username/password for backward compatibility. LTPA login is performed
+eagerly at construction time and mTLS certificates are configured on
+the transport layer.
+
+- **add PyPI publication infrastructure (#142)**
+Add publish workflow (OIDC trusted publishing), CI release gates,
+PyPI version validation script, package metadata, and release
+documentation.
+
+
+## Refactoring
+
+- **remove explicit channel_type arg**
+Expect channel_type in request_parameters for define_channel and update docs/tests.
+
+- **move mq rest exceptions to module**
+- **move MQSC command methods to commands module**
+- **rename _build_response_parameter_map to _build_snake_to_mqsc_map (#102)**
+The previous name was misleading — the function builds a combined
+snake_case → MQSC lookup map, which is request-direction mapping. The
+old name implied it was response-direction. The new name reflects what
+the map actually does regardless of call site.
+
+- **expand opaque MQSC shorthands to descriptive snake_case names (#126)**
+Rename 15 attribute mappings where the snake_case name was a direct
+transliteration of the MQSC shorthand rather than a readable Python
+name.  Domain-standard abbreviations (cf, cpi, mca, psb, qsg, uow)
+are intentionally kept.
+
+- **expand abbreviated snake_case attribute names to descriptive forms (#127)**
+* refactor: expand `q` → `queue` and `q_mgr` → `queue_manager` in attribute names
+
+Expand opaque shorthand prefixes in the snake_case attribute namespace
+to match the descriptive naming convention used elsewhere (e.g.,
+`transmission_queue_time`, `use_dead_letter_queue`).
+
+Two patterns replaced across mapping_data.py, extraction YAMLs,
+generated mapping docs, and all test files:
+
+- `q_mgr` → `queue_manager` (11 unique attributes, ~23 occurrences)
+- `q` → `queue` (27 unique attributes, ~50 occurrences)
+
+- **expand remaining abbreviated snake_case attribute names (#128)**
+Expand 19 shorthand attribute names to descriptive forms:
+- secure_comms → secure_communications
+- sys_name → system_name
+- ssl_client_auth → ssl_client_authentication
+- current/last_luwid → logical_unit_of_work_id
+- psb_name → program_spec_block_name
+- pst_id → partition_spec_table_region_id
+- certificate_val_policy → certificate_validation_policy
+- channel_auto_def_event/exit → channel_auto_define_event/exit
+- chinit_service_parm → chinit_service_parameter
+- cluster_pub_route → cluster_publish_route
+- correl → correlation, comm → communication
+- xmit → transmission, igq → intragroup_queueing
+
+- **expand abbreviated snake_case attribute names (batch 4) (#132)**
+Expand checkpoint, filesystem, log, description, and miscellaneous
+abbreviations to descriptive forms in mapping_data.py (20 renames).
+
+- **use snake_case attribute names exclusively in examples (#133)**
+Remove MQSC fallback patterns (e.g. `get("snake") or get("MQSC", default)`)
+from all examples, using only the mapped snake_case names. This avoids
+encouraging direct use of unmapped MQSC attribute names.
+
+- **require credentials keyword argument, drop username/password (#134)**
+The username/password positional parameters on MQRESTSession.__init__
+were kept for backwards compatibility when credentials support was
+added in #131. Since pymqrest has never been released, there is
+nothing to be compatible with. This simplifies the API to a single
+required credentials keyword argument and removes the _resolve_credentials
+helper and its associated error constants.
+
+- **make perform_ltpa_login internal, remove from public docs (#136)**
+The function is only called from MQRESTSession construction and takes
+internal types (MQRESTTransport, csrf_token) that end users never
+construct directly.  Rename to _perform_ltpa_login and drop the
+LTPA Login section from the authentication docs page.
+
+- **archive extraction pipeline, use MAPPING_DATA as sole source of truth (#140)**
+
+## Testing
+
+- **cover MQREST session helpers**
+Expanded unit coverage for MQRESTSession/transport helpers and tightened typing casts.
+
+- **expand integration display coverage**
+- **generalize integration display and mutating coverage**
+- **run integration lifecycle against local mq**

--- a/releases/v1.0.0.md
+++ b/releases/v1.0.0.md
@@ -1,0 +1,16 @@
+
+# Release 1.0.0 (2026-02-10)
+
+## Documentation
+
+- **rewrite README, fix sphinx markdown lint, close lint coverage gap (#145)**
+Rewrite README with API overview for PyPI landing page. Fix MD040
+(fenced-code-language) and MD029 (ordered-list-prefix) violations in
+docs/sphinx/. Update markdown-standards.sh to run markdownlint on
+docs/sphinx files while skipping structural checks that do not apply
+to MyST/Sphinx pages.
+
+
+## Features
+
+- **bump version to 1.0.0, promote status from experimental to beta (#144)**

--- a/releases/v1.0.1.md
+++ b/releases/v1.0.1.md
@@ -1,0 +1,73 @@
+
+# Release 1.0.1 (2026-02-10)
+
+## Bug fixes
+
+- **resolve bare branch names to origin/ in commit-messages.sh (#159)**
+When the local branch doesn't exist (e.g. main on a develop-only
+checkout), fall back to origin/<ref> to avoid git rev-list failures.
+
+- **use full version in release branch name to avoid collisions (#161)**
+release/X.Y.x collides across patch releases because --delete-branch
+only fires after merge. Switch to release/X.Y.Z so each release gets
+a unique branch name.
+
+- **allow commits on release/* branches in pre-commit hook (#162)**
+* fix: allow commits on release/* branches in pre-commit hook
+
+The prepare_release.py script commits the changelog on the release
+branch. The pre-commit hook was blocking release/* as a protected
+branch, preventing the automated release flow.
+
+- **merge main into release branch to reconcile squash-merge history (#164)**
+Squash merges from develop to main cause history divergence, leading
+to conflicts on subsequent release PRs. The script now merges
+origin/main with strategy=ours after creating the release branch,
+ensuring a clean merge path.
+
+- **use conventional commit message for release merge commit (#165)**
+* fix: use conventional commit message for release merge commit
+
+The commit-msg hook rejects non-conventional commit messages. Use
+chore: prefix for the merge-main-into-release reconciliation commit.
+
+- **create release branch from main to avoid history pollution (#167)**
+The previous approach (branching from develop, merging main with
+strategy=ours) made all develop commits reachable from the release
+branch, causing CI commit-message lint failures on pre-conventional
+commits.
+
+New approach: branch from origin/main and use git commit-tree to
+apply develop's tree content as a single commit. This keeps the
+release branch history clean (only 2 commits ahead of main).
+
+- **generate changelog on develop before creating release branch (#169)**
+git-cliff needs develop-vX.Y.Z boundary tags which are only visible
+from the develop commit history. Generate the changelog on develop,
+capture the tree SHA with git write-tree, then use git commit-tree
+to create the release branch commit from main with the prepared tree.
+This keeps the release branch clean (1 commit ahead of main) while
+ensuring git-cliff sees the correct tag boundaries.
+
+
+## Features
+
+- **auto-bump patch version after publish, bump to 1.0.1 (#147)**
+After a successful PyPI publish, the workflow now creates a PR against
+develop to increment the patch version (e.g. 1.0.0 → 1.0.1). This
+assumes the next release is a patch; the version can be changed to a
+minor or major bump at any point during the development cycle.
+
+The bump is skipped if develop already has the expected next version.
+
+Includes the initial 1.0.0 → 1.0.1 bump to bootstrap the workflow.
+
+- **add changelog with git-cliff and CI validation gate (#149)**
+Introduce automated changelog generation using git-cliff with
+develop-side tags for version boundary tracking. The publish workflow
+now creates develop-vX.Y.Z tags, and a CI gate validates CHANGELOG.md
+contains an entry for the current version on PRs targeting main.
+
+- **add prepare_release.py to automate release preparation (#160)**
+Replace manual release steps (branch, changelog, PR) with a single
+script that orchestrates the full sequence from develop.

--- a/releases/v1.0.2.md
+++ b/releases/v1.0.2.md
@@ -1,0 +1,41 @@
+
+# Release 1.0.2 (2026-02-11)
+
+## Bug fixes
+
+- **use regular merge for release PRs and refresh deps in version bump (#172)**
+Release PRs (release/* → main) now use regular merge commits instead of
+squash merges, eliminating history divergence between main and develop
+and removing the commit-tree workaround in prepare_release.py. The
+post-publish version bump PR now also runs uv lock --upgrade and
+re-exports requirements files.
+
+
+## Documentation
+
+- **add pymqrest 1.0.0 GA announcement draft (#176)**
+* docs: add pymqrest 1.0.0 GA announcement draft
+
+Multi-format announcement (short, medium, micro) with channel-specific
+posting guidance for Reddit, Hacker News, LinkedIn, IBM TechXchange,
+Python Discourse, and Perl communities.
+
+- **use LTPAAuth as default in examples and docs (#181)**
+Switch all example scripts and documentation code samples from BasicAuth
+to LTPAAuth as the recommended credential type for username/password
+scenarios. Reorder auth listings to CertificateAuth, LTPAAuth, BasicAuth.
+Strengthen LTPA guidance in auth docs and add TLS recommendation. Fix
+Python version in README (3.14+ to 3.12+).
+
+
+## Features
+
+- **add Python 3.12 and 3.13 support (#180)**
+Lower requires-python floor from 3.14 to 3.12 and add matrixed CI
+testing for 3.12, 3.13, and 3.14. No source changes needed — all
+modules use `from __future__ import annotations` and 3.10+ syntax.
+
+- **include changed attributes in EnsureResult (#178) (#182)**
+Restructure EnsureResult from an enum into a frozen dataclass with an
+EnsureAction enum for the action discriminant and a changed tuple that
+surfaces which attributes triggered the ALTER command.

--- a/releases/v1.0.3.md
+++ b/releases/v1.0.3.md
@@ -1,0 +1,10 @@
+
+# Release 1.0.3 (2026-02-11)
+
+## Bug fixes
+
+- **merge main back into develop in version bump PR (#186)**
+The publish workflow's version-bump PR only carried pyproject.toml and
+lock files, so CHANGELOG.md and other release-branch artifacts never
+reached develop. Add a git merge origin/main step before the version
+bump so the single PR brings both the main-back-merge and the bump.

--- a/releases/v1.1.0.md
+++ b/releases/v1.1.0.md
@@ -1,0 +1,88 @@
+
+# Release 1.1.0 (2026-02-12)
+
+## Bug fixes
+
+- **use PAT and merge strategy for version bump PR (#190)**
+The bump PR created by publish.yml had two issues:
+
+1. Pushed with GITHUB_TOKEN, which doesn't trigger CI — required
+   status checks never pass and auto-merge can't complete.
+
+2. No auto-merge was configured, requiring manual intervention.
+
+Switch to GITHUB_PR_BUMP_TOKEN (PAT) so the push triggers CI, and
+add `gh pr merge --auto --merge --delete-branch`. The --merge
+strategy (not --squash) preserves the merge commit from
+`git merge origin/main`, maintaining shared ancestry between main
+and develop to prevent changelog conflicts on future releases.
+
+- **skip pre-conventional commits in commit-messages lint**
+The commit-messages.sh linter validates all commits in a PR range,
+which fails on release PRs that include old history predating the
+conventional commits convention. Add a cutoff SHA so commits at or
+before the last non-conventional commit are silently skipped.
+
+- **disable CONNAUTH/CHLAUTH and fix seed idempotency for gateway routing (#200)**
+The IBM MQ container default CHLAUTH catch-all rule blocks inter-QM
+channels, preventing gateway routing. Disable both CONNAUTH and CHLAUTH
+on the containerized queue managers so that inter-QM sender/receiver
+channels can connect. Also tolerate non-zero runmqsc exit codes in
+mq_seed.sh so that re-seeding (e.g. START CHANNEL on an already-running
+channel) does not fail the script. Remove redundant gateway curl
+commands from mq_verify.sh since integration tests already cover those
+paths.
+
+- **remove unused provisional status labels from MAPPING_DATA (#202)**
+All command entries carried a "status" field ("provisional" or
+"no-equivalent") that nothing in runtime code reads. Removing it
+simplifies the data structure. Test fixtures updated to use a
+neutral "description" key instead.
+
+
+## Documentation
+
+- **correct platform availability claim in gateway docs (#203)**
+The MQ REST API is available on all supported IBM MQ platforms
+(Linux, AIX, Windows, z/OS, and IBM i), not just Linux. Updated
+the gateway section to list supported platforms accurately and
+note that pymqrest is developed and tested against Linux only.
+
+- **fix sync-methods examples to use realistic object types (#207)**
+SVRCONN channels are client-initiated and cannot be independently
+started. Replace SVRCONN examples with multiple listeners, which is a
+realistic pattern for queue managers serving different TCP ports.
+
+
+## Features
+
+- **add qmstatus and qstatus qualifier mappings (#192)**
+Split DISPLAY QMSTATUS and DISPLAY QSTATUS into their own qualifiers
+with full response_key_map entries, rather than sharing the qmgr and
+queue qualifiers. This gives each command its own attribute namespace
+for accurate mapping.
+
+Also clean up the doc generator to only produce pages for qualifiers
+that have mappings, and remove stale pages for unmapped qualifiers.
+
+- **add mapping_overrides parameter to MQRESTSession (#194)**
+Allow users to supply sparse mapping overrides at session construction
+that layer on top of the built-in MAPPING_DATA via deep-copy and
+key-level merge, enabling sites with existing naming conventions to
+adopt pymqrest without forking.
+
+- **add gateway_qmgr parameter to MQRESTSession (#197)**
+Enable routing MQSC commands through a gateway queue manager to reach
+remote queue managers on platforms without the REST API (AIX, z/OS,
+Windows). When gateway_qmgr is set, the ibm-mq-rest-gateway-qmgr
+header is included in every request.
+
+- **add MappingOverrideMode.REPLACE for complete mapping replacement (#205)**
+Add MappingOverrideMode enum (MERGE/REPLACE) so callers with a complete
+mapping dataset can replace the built-in MAPPING_DATA entirely, with
+validation that all command and qualifier keys are present.
+
+- **add synchronous start/stop/restart wrappers for channels, listeners, and services (#206)**
+MQSC START/STOP commands are fire-and-forget. These wrappers issue the
+command then poll DISPLAY *STATUS until the object reaches a stable
+state, providing synchronous behaviour for provisioning workflows.

--- a/releases/v1.1.1.md
+++ b/releases/v1.1.1.md
@@ -1,0 +1,14 @@
+
+# Release 1.1.1 (2026-02-13)
+
+## Documentation
+
+- **add developer setup and contributing guides to Sphinx docs (#215)**
+
+## Features
+
+- **migrate MQ dev environment to shared mq-dev-environment repo (#214)**
+Replace bundled Docker setup with thin wrapper scripts that delegate
+to the mq-dev-environment sibling repository. Rename all PYMQREST.*
+object references to DEV.* and add CI integration testing via the
+shared composite action.

--- a/releases/v1.1.10.md
+++ b/releases/v1.1.10.md
@@ -1,0 +1,7 @@
+
+# Release 1.1.10 (2026-02-21)
+
+## Bug fixes
+
+- **scope Python linters to src/ and tests/, sync standard-tooling v1.1.4 (#352)**
+Exclude scripts/ from ruff to avoid conflicts with centrally managed standard-tooling scripts. Remove now-unnecessary per-file-ignores for scripts/. Sync all shared scripts from standard-tooling v1.1.4.

--- a/releases/v1.1.11.md
+++ b/releases/v1.1.11.md
@@ -1,0 +1,6 @@
+
+# Release 1.1.11 (2026-02-23)
+
+## Bug fixes
+
+- **update add-to-project action to v1.0.2 (#357)**

--- a/releases/v1.1.2.md
+++ b/releases/v1.1.2.md
@@ -1,0 +1,14 @@
+
+# Release 1.1.2 (2026-02-13)
+
+## Bug fixes
+
+- **use PR_BUMP_TOKEN for version bump PR creation (#219)**
+The version bump PR step referenced GITHUB_PR_BUMP_TOKEN, but GitHub
+does not allow secrets prefixed with GITHUB_. Use PR_BUMP_TOKEN
+instead, falling back to the built-in github.token if not set.
+
+- **prevent release-gates skipped status from blocking auto-merge (#223)**
+Move the pull_request condition from job-level if: to step-level if:
+so the job always runs (satisfying the required check) but only
+performs validation on pull_request events.

--- a/releases/v1.1.3.md
+++ b/releases/v1.1.3.md
@@ -1,0 +1,56 @@
+
+# Release 1.1.3 (2026-02-15)
+
+## Bug fixes
+
+- **add missing MAPPING_DATA entries for integration test failures (#236)**
+Add missing response_key_map entries for attributes returned by the MQ
+REST API: CHANNEL, CONNAME, CURRENT, XMITQ (chstatus); CHANNEL,
+DEFRECON, TMPMODEL, TMPQPRFX (channel); LISTENER, TRPTYPE (listener);
+NAMELIST (namelist); PROCESS (process); TYPE (qmstatus); QUEUE
+(qstatus/queue); NOSHARE, NOTRIGGER, QSVCIEV, TARGET, TYPE (queue);
+PUB, SUB, TOPIC (topic).
+
+Add YES/NO to DEFPSIST response and request value maps. Add
+target_queue_name to queue request_key_map. Add request_key_value_map
+for listener (replace/noreplace).
+
+Add DELETE QLOCAL, DELETE QREMOTE, DELETE QALIAS, DELETE QMODEL commands
+to MAPPING_DATA. Fix lifecycle tests to use specific delete methods
+instead of the generic delete_queue which sends an invalid DELETE QUEUE
+MQSC command.
+
+Fix integration tests and examples to use canonical mapped parameter
+names (ha_status not status for qmstatus, start_mode not control for
+listener, dead_letter_queue_name not dead_letter_q_name for qmgr,
+replace "yes" not "YES", transmission_queue_name not xmit_q_name,
+default_persistence not def_persistence, default_input_open_option not
+default_share_option, remote_queue_manager_name not remote_q_mgr_name).
+
+Fix namelist lifecycle test to pass names as list (MQCFSL type requires
+array). Mark LTPA auth test as xfail (developer container limitation).
+
+Regenerate commands.py (132 → 136 methods) and mapping docs.
+
+- **allow release/* commits in library-release branching model (#244)**
+The canonical pre-commit hook hard-blocked release/* as a protected
+branch, but the library-release model requires committing changelog
+updates on release/* during the prepare_release.py flow.
+
+
+## Documentation
+
+- **add nested object flattening design doc and queue status example (#240)**
+Add a dedicated design document explaining the _flatten_nested_objects()
+algorithm, edge cases, and pipeline placement. Add queue_status.py
+example demonstrating DISPLAY QSTATUS TYPE(HANDLE) and DISPLAY CONN
+TYPE(HANDLE) queries. Condense the inline flattening section in
+runcommand-endpoint.md to cross-reference the new doc.
+
+
+## Features
+
+- **adopt per-project MQ container isolation (#233)**
+Set COMPOSE_PROJECT_NAME=pymqrest in all MQ lifecycle wrapper scripts
+and pass project-name to the setup-mq CI action so multiple projects
+can run integration tests simultaneously without collisions.

--- a/releases/v1.1.4.md
+++ b/releases/v1.1.4.md
@@ -1,0 +1,136 @@
+
+# Release 1.1.4 (2026-02-16)
+
+## Bug fixes
+
+- **remove extra blank line in CHANGELOG.md**
+- **disable MD041 for mkdocs snippet-include files**
+The docs/site/docs/mappings/*.md files are mkdocs snippet includes
+(--8<-- directives), not standalone markdown documents. MD041 (first
+line must be a heading) false-positives on these. The awk structural
+check in standards-compliance already enforces single-H1 for real docs.
+
+- **correct snippets base_path resolution for fragment includes (#267)**
+pymdownx.snippets resolves base_path relative to CWD (not the mkdocs.yml
+location). The previous paths were relative to docs/site/ which caused
+fragments to either not resolve or self-include when the wrapper file
+had the same name as the fragment.
+
+Use CWD-relative paths so fragments resolve correctly when mkdocs is
+invoked from the repository root.
+
+Ref wphillipmoore/mq-rest-admin-common#32
+
+- **run mike from repo root so snippet base_path resolves in CI (#268)**
+Remove working-directory from mike deploy step and pass
+-F docs/site/mkdocs.yml instead, so CWD matches the base_path
+entries in mkdocs.yml.
+
+Ref wphillipmoore/mq-rest-admin-common#32
+
+- **remove PR_BUMP_TOKEN and add issue linkage to version bump PR**
+Remove the PR_BUMP_TOKEN secret fallback from the version bump step,
+using github.token directly instead. Remove the corresponding
+git remote set-url that configured token-based auth, since the
+default GITHUB_TOKEN already has push access.
+
+After creating the version bump PR, extract the PR number and edit
+the body to include a self-referencing issue link (Ref #N), then
+close and reopen the PR to trigger notification workflows before
+enabling auto-merge.
+
+- **rename integration-test job to integration-tests**
+Standardize CI job naming across all library repos. Java already
+uses integration-tests (plural); this aligns Python to match.
+
+- **move SBOM generation after PyPI publish step (#284)**
+The SBOM .cdx.json file was being written to dist/ before the PyPI
+publish step, causing pypa/gh-action-pypi-publish to reject the
+unknown distribution format. Move the SBOM generation after publish
+but before the GitHub Release so dist/ only contains valid Python
+distributions during upload to PyPI.
+
+- **sync prepare_release.py with canonical version (#286)**
+Add --issue argument for tracking issue linkage in release PR body.
+Add merge_main() step to prevent CHANGELOG.md merge conflicts by
+incorporating main's history before generating the changelog.
+
+
+## Documentation
+
+- **migrate from Sphinx to MkDocs Material**
+Replace Sphinx+MyST+Furo with MkDocs Material to align with the Java
+repo and enable shared documentation fragments via pymdownx.snippets.
+
+- Move doc sources from docs/sphinx/ to docs/site/docs/
+- Convert {doc} cross-references to standard Markdown links
+- Convert eval-rst/autoclass blocks to mkdocstrings syntax
+- Add mkdocs.yml with Material theme and mkdocstrings[python] plugin
+- Update pyproject.toml dependencies and CI workflow
+- Delete Sphinx conf.py and old docs directory
+
+- **fix attribute names, stale auth claim, and bare pages (#251)**
+- **address medium-severity documentation consistency findings (#253)**
+Rewrite architecture.md to use shared fragment includes matching the Java
+pattern, add transport mocking guidance, create api/transport.md, rewrite
+exceptions.md with usage examples, normalize "Python names" to "Developer
+names" in mapping-pipeline.md, and set dark mode as default theme palette.
+
+- **address cross-library documentation consistency nits (#259)**
+Enrich API reference pages with overviews, code examples, inline type
+definitions, and structured tables to match Java/Go quality. Add code
+examples to mapping pipeline page, restructure API index, standardize
+nav ordering, and add architecture cross-references.
+
+- **switch to shared fragment includes from common repo (#264)**
+Replace duplicated mapping pages, AI engineering, local MQ container,
+and design docs with --8<-- snippet includes from mq-rest-admin-common.
+Delete generate_mapping_docs.py (moved to common).
+
+- **add quality gates documentation page**
+Include the shared quality gates fragment from mq-rest-admin-common and
+append Python-specific validation pipeline details (ruff, mypy, ty,
+pytest, pip-audit, uv lock check).
+
+- **remove Python-specific design choices and beta status from rationale**
+These sections are redundant with the API reference documentation and
+no longer applicable.
+
+- **update CLAUDE.md architecture section for current codebase (#276)**
+Update the architecture section to reflect the current module structure:
+- Mapping data now references JSON file and thin Python loader
+- Add auth.py, ensure.py, sync.py, and _mapping_merge.py sections
+- Add MQRESTAuthError and MQRESTTimeoutError to exceptions list
+
+
+## Features
+
+- **add Tier 1 security tooling (CodeQL, attestations, license compliance)**
+- Add CodeQL SAST job to CI workflow using standard-actions composite action
+- Add build provenance attestations to publish workflow (attest-build-provenance@v2)
+- Add pip-licenses dependency with GPL-compatible license allowlist
+- Add license compliance check to CI dependency-audit job and local validation
+
+Ref wphillipmoore/mq-rest-admin-common#20
+Ref wphillipmoore/mq-rest-admin-common#21
+Ref wphillipmoore/mq-rest-admin-common#22
+
+- **add Trivy and Semgrep CI jobs and SBOM generation**
+Add Trivy filesystem vulnerability scanning and Semgrep SAST jobs to CI,
+gated by docs-only detection. Add CycloneDX SBOM generation to the
+publish workflow, attached to GitHub Releases alongside build artifacts.
+
+Ref mq-rest-admin-common#11, #24, #25
+
+
+## Refactoring
+
+- **convert mapping data from Python module to JSON file (#274)**
+Replace the 1956-line inline Python dict in mapping_data.py with a JSON
+file loaded at import time. The JSON file is copied from the canonical
+source in mq-rest-admin-common.
+
+- Add src/pymqrest/mapping-data.json (from mq-rest-admin-common)
+- Rewrite mapping_data.py to load from JSON via json.loads()
+- Update generate_commands.py to use json.loads() instead of importlib
+- Add mapping-data.json to pyproject.toml package-data

--- a/releases/v1.1.5.md
+++ b/releases/v1.1.5.md
@@ -1,0 +1,18 @@
+
+# Release 1.1.5 (2026-02-16)
+
+## Bug fixes
+
+- **move SBOM generation after PyPI publish step (#284) (#287)**
+Cherry-pick SBOM ordering fix to main to unblock v1.1.4 publish
+
+- **sync prepare_release.py merge message fix from canonical (#291)**
+- **sync prepare_release.py changelog conflict fix from canonical (#293)**
+
+## Styling
+
+- **fix ruff lint errors in prepare_release.py (#288)**
+* style: fix ruff lint errors in prepare_release.py
+
+Apply ruff auto-fixes for I001 (import block sorting) and PTH201
+(remove explicit current directory in Path constructor).

--- a/releases/v1.1.6.md
+++ b/releases/v1.1.6.md
@@ -1,0 +1,13 @@
+
+# Release 1.1.6 (2026-02-17)
+
+## Bug fixes
+
+- **sync prepare_release.py ruff formatting from canonical (#298)**
+
+## Features
+
+- **use GitHub App token for bump PR to trigger CI (#300)**
+PRs created by GITHUB_TOKEN do not trigger workflow runs (GitHub
+security limitation). Replace with a GitHub App installation token
+so CI runs automatically on bump PRs.

--- a/releases/v1.1.7.md
+++ b/releases/v1.1.7.md
@@ -1,0 +1,6 @@
+
+# Release 1.1.7 (2026-02-17)
+
+## Bug fixes
+
+- **sync prepare_release.py empty changelog abort from canonical (#307)**

--- a/releases/v1.1.8.md
+++ b/releases/v1.1.8.md
@@ -1,0 +1,72 @@
+
+# Release 1.1.8 (2026-02-19)
+
+## Bug fixes
+
+- **sync shared tooling to v1.0.2**
+Update sync-tooling.sh from standard-tooling v1.0.2:
+- Fix --actions-compat flag leaking during self-update re-exec
+- Add canonical source comment to repo-profile.sh
+
+- **revert Python 3.10 CI matrix expansion (#323)**
+Reverts commit 9c8ee2c which broke CI — the validation scripts use
+tomllib (Python 3.11+) but ran under bare python3 on the 3.10 matrix.
+The PR auto-merged despite failing gates, which is a separate branch
+protection bug.
+
+This reverts commit 9c8ee2cf443fb0e8495d5479645249181a25776a.
+
+- **sync hook and lint scripts from standards-and-conventions (#324)**
+* fix: sync hook and lint scripts from standards-and-conventions
+
+Close git revert hook bypass by adding branch protection to commit-msg
+hook, accept Revert commit messages, and support cross-repo issue linkage.
+
+Ref wphillipmoore/mq-rest-admin-common#62
+
+
+## CI
+
+- **auto-add issues to GitHub Project (#319)**
+* chore: add workflow to auto-add issues to GitHub Project
+
+* chore: retrigger CI with corrected PR body
+
+
+## Documentation
+
+- **rename mq-dev-environment references to mq-rest-admin-dev-environment (#325)**
+Update CI workflow, CLAUDE.md, shell scripts, developer-setup docs, and
+MQ container docs to use the new repository name, aligning with the
+mq-rest-admin-* naming convention.
+
+The historical CHANGELOG.md entry is left as-is.
+
+Ref wphillipmoore/mq-dev-environment#14
+
+
+## Features
+
+- **sync shared tooling from standard-tooling v1.0.0**
+Replace stale local copies with canonical versions from
+standard-tooling. Key changes:
+- commit-messages.sh: env-var COMMIT_CUTOFF_SHA replaces hardcoded SHA
+- pr-issue-linkage.sh: accepts all GitHub closing keywords
+- prepare_release.py: adds ensure_develop_up_to_date() check
+- Adds sync-tooling.sh and finalize_repo.sh
+
+- **extend CI matrix to Python 3.10+ to discover minimum supported version (#322)**
+Lower requires-python from >=3.12 to >=3.10, expand the CI test matrix
+to cover 3.10 through 3.14, and fix ruff lint issues triggered by the
+lower target version (import sorting in scripts, PERF203 in integration
+tests). No library source changes required — the code supports 3.10 as-is.
+
+
+## Refactoring
+
+- **use shared docs-deploy composite action (#329)**
+- **use shared composite actions for publish and release gates (#333)**
+Replace inline tag/release, version bump PR, and version divergence gate logic with reusable composite actions from standard-actions.
+
+- publish.yml: use tag-and-release and version-bump-pr actions
+- ci.yml: use version-divergence action for release gates

--- a/releases/v1.1.9.md
+++ b/releases/v1.1.9.md
@@ -1,0 +1,21 @@
+
+# Release 1.1.9 (2026-02-20)
+
+## Documentation
+
+- **ban MEMORY.md usage in CLAUDE.md (#339)**
+Add auto-memory policy requiring agents to discuss behavioral rules with the human rather than storing them in unmanaged MEMORY.md files.
+
+- **ban heredocs in shell commands (#340)**
+Add explicit ban on heredocs for multi-line CLI arguments. Always use temp files instead.
+
+
+## Features
+
+- **add category prefixes to job names (#338)**
+Standardize job display names with category prefixes so checks cluster naturally in the GitHub status list.
+
+- **adopt validate_local.sh dispatch architecture (#341)**
+* feat(validate): adopt validate_local.sh dispatch architecture
+
+Add primary_language: python to repo profile. Replace validate_local.py with synced shell-based driver and language-specific scripts. Extract license allowlist to .pip-licenses-allowlist. Create validate_local_custom.sh for repo-specific checks (validate_venv, validate_dependency_specs, validate_version, mypy/ty on examples/).

--- a/releases/v1.2.0.md
+++ b/releases/v1.2.0.md
@@ -1,0 +1,20 @@
+
+# Release 1.2.0 (2026-02-24)
+
+## CI
+
+- **add SonarCloud quality analysis to CI (#366)**
+- **add SonarCloud post-merge workflow (#367)**
+Runs SonarCloud analysis on push to develop so the project dashboard reflects the latest merged code.
+
+- **add Code Climate (Qlty) coverage upload (#369)**
+Add codeclimate job to ci.yml and codeclimate.yml post-merge workflow for Qlty Cloud coverage tracking via OIDC.
+
+- **assign unique REST API ports per integration test matrix entry (#372)**
+* ci: assign unique REST API ports per integration test matrix entry
+
+
+## Features
+
+- **run integration tests with same Python version matrix as unit tests (#370)**
+Integration tests now run against Python 3.12, 3.13, and 3.14 instead of only 3.14, matching the unit test matrix for consistent coverage.


### PR DESCRIPTION
# Pull Request

## Summary

- Generate retroactive per-release verbose notes for all 18 existing releases (v0.1.0 through v1.2.0) using git-cliff. Fix template whitespace and extend markdownlint relaxations for raw commit body content.

## Issue Linkage

- Fixes #385

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -