### PR TITLE
chore(docs): consolidate MkDocs nav sections

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -69,23 +69,26 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Releases:
+      - Release Notes: releases/index.md
+      - Changelog: changelog.md
   - Getting Started: getting-started.md
   - Architecture: architecture.md
-  - Mapping Pipeline: mapping-pipeline.md
-  - Ensure Methods: ensure-methods.md
-  - Sync Methods: sync-methods.md
   - Examples: examples.md
   - API Reference:
       - api/index.md
       - Session: api/session.md
       - Authentication: api/auth.md
       - Commands: api/commands.md
+      - Ensure Methods: ensure-methods.md
+      - Sync Methods: sync-methods.md
       - Transport: api/transport.md
       - Mapping: api/mapping.md
       - Ensure: api/ensure.md
       - Sync: api/sync.md
       - Exceptions: api/exceptions.md
   - Mappings:
+      - Mapping Pipeline: mapping-pipeline.md
       - mappings/index.md
       - apstatus: mappings/apstatus.md
       - archive: mappings/archive.md
@@ -142,7 +145,4 @@ nav:
       - Generation Scripts: development/generation-scripts.md
       - Namespace Origin: development/namespace-origin.md
       - Release Workflow: development/release-workflow.md
-  - Releases:
-      - Release Notes: releases/index.md
-      - Changelog: changelog.md
-  - AI Engineering: ai-engineering.md
+      - AI Engineering: ai-engineering.md


### PR DESCRIPTION
## Summary

- Consolidate MkDocs nav from 12 to 8 top-level sections
- Move Releases to second position (after Home)
- Absorb Mapping Pipeline, Ensure Methods, Sync Methods, and AI Engineering into their parent sections

Fixes #389

## Test plan

- [x] docs-only change, no code impact

> Generated with [Claude Code](https://claude.com/claude-code)
