### PR TITLE
fix(docs): correct relative links to mapping-pipeline in api/ensure and api/sync

### DIFF
--- a/docs/site/docs/api/ensure.md
+++ b/docs/site/docs/api/ensure.md
@@ -164,7 +164,7 @@ corrupting `ALTDATE`/`ALTTIME` on every run.
 ## Attribute mapping
 
 The ensure methods participate in the same
-[mapping pipeline](mapping-pipeline.md) as all other command methods.
+[mapping pipeline](../mapping-pipeline.md) as all other command methods.
 Pass `snake_case` attribute names in `request_parameters` and the
 mapping layer translates them to MQSC names for the DISPLAY, DEFINE,
 and ALTER commands automatically.

--- a/docs/site/docs/api/sync.md
+++ b/docs/site/docs/api/sync.md
@@ -175,7 +175,7 @@ treated as stopped for those object types.
 ## Attribute mapping
 
 The sync methods call `_mqsc_command` internally, so they participate
-in the same [mapping pipeline](mapping-pipeline.md) as all other
+in the same [mapping pipeline](../mapping-pipeline.md) as all other
 command methods. The status key is checked using both the mapped
 `snake_case` name and the raw MQSC name, so polling works correctly
 regardless of whether mapping is enabled or disabled.


### PR DESCRIPTION
# Pull Request

## Summary

- Fix broken mapping-pipeline relative links in api/ensure.md and api/sync.md that caused docs build failure in strict mode

## Issue Linkage

- Fixes #399

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -