### PR TITLE
refactor(naming): rename abbreviated local variables to complete English words

### DIFF
--- a/src/pymqrest/_mapping_merge.py
+++ b/src/pymqrest/_mapping_merge.py
@@ -50,49 +50,49 @@ def validate_mapping_overrides(overrides: Mapping[str, object]) -> None:
 def _validate_top_level_keys(overrides: Mapping[str, object]) -> None:
     for key in overrides:
         if key not in _VALID_TOP_LEVEL_KEYS:
-            msg = f"Invalid top-level key in mapping_overrides: {key!r} (expected subset of {sorted(_VALID_TOP_LEVEL_KEYS)})"
-            raise ValueError(msg)
+            message = f"Invalid top-level key in mapping_overrides: {key!r} (expected subset of {sorted(_VALID_TOP_LEVEL_KEYS)})"
+            raise ValueError(message)
 
 
 def _validate_commands_section(commands: object) -> None:
     if commands is None:
         return
     if not isinstance(commands, Mapping):
-        msg = "mapping_overrides['commands'] must be a Mapping"
-        raise TypeError(msg)
+        message = "mapping_overrides['commands'] must be a Mapping"
+        raise TypeError(message)
     commands_map = cast("Mapping[str, object]", commands)
     for command_key, command_entry in commands_map.items():
         if not isinstance(command_entry, Mapping):
-            msg = f"mapping_overrides['commands'][{command_key!r}] must be a Mapping"
-            raise TypeError(msg)
+            message = f"mapping_overrides['commands'][{command_key!r}] must be a Mapping"
+            raise TypeError(message)
 
 
 def _validate_qualifiers_section(qualifiers: object) -> None:
     if qualifiers is None:
         return
     if not isinstance(qualifiers, Mapping):
-        msg = "mapping_overrides['qualifiers'] must be a Mapping"
-        raise TypeError(msg)
+        message = "mapping_overrides['qualifiers'] must be a Mapping"
+        raise TypeError(message)
     qualifiers_map = cast("Mapping[str, object]", qualifiers)
     for qualifier_key, qualifier_entry in qualifiers_map.items():
         if not isinstance(qualifier_entry, Mapping):
-            msg = f"mapping_overrides['qualifiers'][{qualifier_key!r}] must be a Mapping"
-            raise TypeError(msg)
+            message = f"mapping_overrides['qualifiers'][{qualifier_key!r}] must be a Mapping"
+            raise TypeError(message)
         _validate_qualifier_entry(qualifier_key, cast("Mapping[str, object]", qualifier_entry))
 
 
 def _validate_qualifier_entry(qualifier_key: str, entry: Mapping[str, object]) -> None:
     for sub_key in entry:
         if sub_key not in _VALID_QUALIFIER_SUB_KEYS:
-            msg = (
+            message = (
                 f"Invalid sub-key {sub_key!r} in mapping_overrides['qualifiers'][{qualifier_key!r}] "
                 f"(expected subset of {sorted(_VALID_QUALIFIER_SUB_KEYS)})"
             )
-            raise ValueError(msg)
+            raise ValueError(message)
         sub_value = entry[sub_key]
         if not isinstance(sub_value, Mapping):
-            msg = f"mapping_overrides['qualifiers'][{qualifier_key!r}][{sub_key!r}] must be a Mapping"
-            raise TypeError(msg)
+            message = f"mapping_overrides['qualifiers'][{qualifier_key!r}][{sub_key!r}] must be a Mapping"
+            raise TypeError(message)
 
 
 def merge_mapping_data(
@@ -204,8 +204,8 @@ def validate_mapping_overrides_complete(
 
     if missing_parts:
         detail = "\n".join(f"  {entry}" for entry in missing_parts)
-        msg = f"mapping_overrides is incomplete for REPLACE mode. Missing entries:\n{detail}"
-        raise ValueError(msg)
+        message = f"mapping_overrides is incomplete for REPLACE mode. Missing entries:\n{detail}"
+        raise ValueError(message)
 
 
 def replace_mapping_data(overrides: Mapping[str, object]) -> dict[str, object]:

--- a/src/pymqrest/sync.py
+++ b/src/pymqrest/sync.py
@@ -347,7 +347,7 @@ class MQRESTSyncMixin:
         config: SyncConfig | None,
     ) -> SyncResult:
         """Issue START then poll until the object is RUNNING."""
-        cfg = config or SyncConfig()
+        sync_config = config or SyncConfig()
         self._mqsc_command(
             command="START",
             mqsc_qualifier=obj_config.start_qualifier,
@@ -358,7 +358,7 @@ class MQRESTSyncMixin:
         polls = 0
         start_time = time.monotonic()
         while True:
-            time.sleep(cfg.poll_interval_seconds)
+            time.sleep(sync_config.poll_interval_seconds)
             status_rows = self._mqsc_command(
                 command="DISPLAY",
                 mqsc_qualifier=obj_config.status_qualifier,
@@ -371,10 +371,12 @@ class MQRESTSyncMixin:
                 elapsed = time.monotonic() - start_time
                 return SyncResult(SyncOperation.STARTED, polls=polls, elapsed_seconds=elapsed)
             elapsed = time.monotonic() - start_time
-            if elapsed >= cfg.timeout_seconds:
-                msg = f"{obj_config.start_qualifier} '{name}' did not reach RUNNING within {cfg.timeout_seconds}s"
+            if elapsed >= sync_config.timeout_seconds:
+                message = (
+                    f"{obj_config.start_qualifier} '{name}' did not reach RUNNING within {sync_config.timeout_seconds}s"
+                )
                 raise MQRESTTimeoutError(
-                    msg,
+                    message,
                     name=name,
                     operation="start",
                     elapsed=elapsed,
@@ -387,7 +389,7 @@ class MQRESTSyncMixin:
         config: SyncConfig | None,
     ) -> SyncResult:
         """Issue STOP then poll until the object is STOPPED."""
-        cfg = config or SyncConfig()
+        sync_config = config or SyncConfig()
         self._mqsc_command(
             command="STOP",
             mqsc_qualifier=obj_config.stop_qualifier,
@@ -398,7 +400,7 @@ class MQRESTSyncMixin:
         polls = 0
         start_time = time.monotonic()
         while True:
-            time.sleep(cfg.poll_interval_seconds)
+            time.sleep(sync_config.poll_interval_seconds)
             status_rows = self._mqsc_command(
                 command="DISPLAY",
                 mqsc_qualifier=obj_config.status_qualifier,
@@ -414,10 +416,12 @@ class MQRESTSyncMixin:
                 elapsed = time.monotonic() - start_time
                 return SyncResult(SyncOperation.STOPPED, polls=polls, elapsed_seconds=elapsed)
             elapsed = time.monotonic() - start_time
-            if elapsed >= cfg.timeout_seconds:
-                msg = f"{obj_config.stop_qualifier} '{name}' did not reach STOPPED within {cfg.timeout_seconds}s"
+            if elapsed >= sync_config.timeout_seconds:
+                message = (
+                    f"{obj_config.stop_qualifier} '{name}' did not reach STOPPED within {sync_config.timeout_seconds}s"
+                )
                 raise MQRESTTimeoutError(
-                    msg,
+                    message,
                     name=name,
                     operation="stop",
                     elapsed=elapsed,

--- a/tests/pymqrest/test_mapping_merge.py
+++ b/tests/pymqrest/test_mapping_merge.py
@@ -117,9 +117,9 @@ def test_merge_commands_shallow_merge() -> None:
 
     merged = merge_mapping_data(base, overrides)
 
-    cmd = merged["commands"]["DISPLAY QUEUE"]  # type: ignore[index]
-    assert cmd["qualifier"] == "queue"
-    assert cmd["description"] == "override"
+    command = merged["commands"]["DISPLAY QUEUE"]  # type: ignore[index]
+    assert command["qualifier"] == "queue"
+    assert command["description"] == "override"
 
 
 def test_merge_commands_adds_new_command() -> None:

--- a/tests/pymqrest/test_sync.py
+++ b/tests/pymqrest/test_sync.py
@@ -120,19 +120,19 @@ def _build_session(
 
 class TestSyncConfig:
     def test_defaults(self) -> None:
-        cfg = SyncConfig()
-        assert cfg.timeout_seconds == DEFAULT_TIMEOUT_SECONDS
-        assert cfg.poll_interval_seconds == ELAPSED_ONE_SECOND
+        sync_config = SyncConfig()
+        assert sync_config.timeout_seconds == DEFAULT_TIMEOUT_SECONDS
+        assert sync_config.poll_interval_seconds == ELAPSED_ONE_SECOND
 
     def test_custom_values(self) -> None:
-        cfg = SyncConfig(timeout_seconds=10.0, poll_interval_seconds=0.5)
-        assert cfg.timeout_seconds == CUSTOM_TIMEOUT_SECONDS
-        assert cfg.poll_interval_seconds == ELAPSED_HALF_SECOND
+        sync_config = SyncConfig(timeout_seconds=10.0, poll_interval_seconds=0.5)
+        assert sync_config.timeout_seconds == CUSTOM_TIMEOUT_SECONDS
+        assert sync_config.poll_interval_seconds == ELAPSED_HALF_SECOND
 
     def test_frozen(self) -> None:
-        cfg = SyncConfig()
+        sync_config = SyncConfig()
         with pytest.raises(AttributeError):
-            cfg.timeout_seconds = 99.0  # type: ignore[misc]
+            sync_config.timeout_seconds = 99.0  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -179,20 +179,20 @@ class TestSyncResult:
 
 class TestMQRESTTimeoutError:
     def test_attributes(self) -> None:
-        err = MQRESTTimeoutError(
+        error = MQRESTTimeoutError(
             "timed out",
             name="MY.CHL",
             operation="start",
             elapsed=30.5,
         )
-        assert str(err) == "timed out"
-        assert err.name == "MY.CHL"
-        assert err.operation == "start"
-        assert err.elapsed == EXPECT_ELAPSED_30_5
+        assert str(error) == "timed out"
+        assert error.name == "MY.CHL"
+        assert error.operation == "start"
+        assert error.elapsed == EXPECT_ELAPSED_30_5
 
     def test_is_mqrest_error(self) -> None:
-        err = MQRESTTimeoutError("t", name="X", operation="stop", elapsed=1.0)
-        assert isinstance(err, MQRESTError)
+        error = MQRESTTimeoutError("t", name="X", operation="stop", elapsed=1.0)
+        assert isinstance(error, MQRESTError)
 
 
 # ---------------------------------------------------------------------------
@@ -272,8 +272,8 @@ class TestStartChannelSync:
         running = _success_payload([{"STATUS": "RUNNING"}])
         session, _transport = _build_session([start_response, running])
 
-        cfg = SyncConfig(timeout_seconds=5.0, poll_interval_seconds=0.5)
-        result = session.start_channel_sync("MY.CHL", config=cfg)
+        sync_config = SyncConfig(timeout_seconds=5.0, poll_interval_seconds=0.5)
+        result = session.start_channel_sync("MY.CHL", config=sync_config)
 
         assert result.operation is SyncOperation.STARTED
         assert result.elapsed_seconds == ELAPSED_HALF_SECOND


### PR DESCRIPTION
# Pull Request

## Summary

- Rename abbreviated internal variables to complete English words per naming standards Rule 3

## Issue Linkage

- Ref #226

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- Internal-only renames (cfg, msg, err, cmd). No public API changes. 100% test coverage maintained.