### PR TITLE
chore: standardize integration test configuration

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -20,6 +20,6 @@ jobs:
       security-events: write
     with:
       python-versions: '["3.14"]'
-      integration-matrix: '[{"python-version":"3.14","project-suffix":"3-14","qm1-rest-port":"9451","qm2-rest-port":"9452"}]'
+      integration-matrix: '[{"python-version":"3.14","project-suffix":"3-14","qm1-rest-port":"9451","qm2-rest-port":"9452","qm1-mq-port":"1420","qm2-mq-port":"1421"}]'
       run-security: 'false'
       run-release-gates: 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
         default: '["3.12", "3.13", "3.14"]'
       integration-matrix:
         type: string
-        default: '[{"python-version":"3.12","project-suffix":"3-12","qm1-rest-port":"9447","qm2-rest-port":"9448"},{"python-version":"3.13","project-suffix":"3-13","qm1-rest-port":"9449","qm2-rest-port":"9450"},{"python-version":"3.14","project-suffix":"3-14","qm1-rest-port":"9451","qm2-rest-port":"9452"}]'
+        default: '[{"python-version":"3.12","project-suffix":"3-12","qm1-rest-port":"9447","qm2-rest-port":"9448","qm1-mq-port":"1416","qm2-mq-port":"1417"},{"python-version":"3.13","project-suffix":"3-13","qm1-rest-port":"9449","qm2-rest-port":"9450","qm1-mq-port":"1418","qm2-mq-port":"1419"},{"python-version":"3.14","project-suffix":"3-14","qm1-rest-port":"9451","qm2-rest-port":"9452","qm1-mq-port":"1420","qm2-mq-port":"1421"}]'
       run-security:
         type: string
         default: 'true'
@@ -137,7 +137,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(inputs.integration-matrix || '[{"python-version":"3.12","project-suffix":"3-12","qm1-rest-port":"9447","qm2-rest-port":"9448"},{"python-version":"3.13","project-suffix":"3-13","qm1-rest-port":"9449","qm2-rest-port":"9450"},{"python-version":"3.14","project-suffix":"3-14","qm1-rest-port":"9451","qm2-rest-port":"9452"}]') }}
+        include: ${{ fromJSON(inputs.integration-matrix || '[{"python-version":"3.12","project-suffix":"3-12","qm1-rest-port":"9447","qm2-rest-port":"9448","qm1-mq-port":"1416","qm2-mq-port":"1417"},{"python-version":"3.13","project-suffix":"3-13","qm1-rest-port":"9449","qm2-rest-port":"9450","qm1-mq-port":"1418","qm2-mq-port":"1419"},{"python-version":"3.14","project-suffix":"3-14","qm1-rest-port":"9451","qm2-rest-port":"9452","qm1-mq-port":"1420","qm2-mq-port":"1421"}]') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -153,9 +153,11 @@ jobs:
       - name: Setup MQ environment
         uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
-          project-name: pymqrest-${{ matrix.project-suffix }}
+          project-name: mqrest-python-${{ matrix.project-suffix }}
           qm1-rest-port: ${{ matrix.qm1-rest-port }}
           qm2-rest-port: ${{ matrix.qm2-rest-port }}
+          qm1-mq-port: ${{ matrix.qm1-mq-port }}
+          qm2-mq-port: ${{ matrix.qm2-mq-port }}
 
       - name: Run integration tests
         env:
@@ -163,7 +165,7 @@ jobs:
           MQ_REST_BASE_URL_QM2: https://localhost:${{ matrix.qm2-rest-port }}/ibmmq/rest/v2
         run: |
           MQ_SKIP_LIFECYCLE=1 \
-          PYMQREST_RUN_INTEGRATION=1 \
+          MQ_REST_ADMIN_RUN_INTEGRATION=1 \
           uv run pytest -m integration
 
   # ---------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ uv run pytest --cov=pymqrest --cov-report=term-missing --cov-branch --cov-fail-u
 uv run pytest tests/pymqrest/test_session.py
 
 # Run integration tests (requires local MQ container)
-PYMQREST_RUN_INTEGRATION=1 uv run pytest -m integration
+MQ_REST_ADMIN_RUN_INTEGRATION=1 uv run pytest -m integration
 ```
 
 ### Linting and Formatting

--- a/docs/mq-container-local-dev.md
+++ b/docs/mq-container-local-dev.md
@@ -155,7 +155,7 @@ Integration tests live in `tests/integration/test_mq_integration.py`. The tests
 are skipped by default and require an explicit opt-in:
 
 ```bash
-PYMQREST_RUN_INTEGRATION=1 uv run pytest -m integration
+MQ_REST_ADMIN_RUN_INTEGRATION=1 uv run pytest -m integration
 ```
 
 When enabled, the tests:

--- a/docs/site/docs/development/developer-setup.md
+++ b/docs/site/docs/development/developer-setup.md
@@ -101,7 +101,7 @@ seed test objects, then run the tests:
 ./scripts/dev/mq_seed.sh
 
 # Run integration tests
-PYMQREST_RUN_INTEGRATION=1 uv run pytest -m integration
+MQ_REST_ADMIN_RUN_INTEGRATION=1 uv run pytest -m integration
 ```
 
 See [local MQ container](local-mq-container.md) for full container configuration,

--- a/docs/site/docs/development/local-mq-container.md
+++ b/docs/site/docs/development/local-mq-container.md
@@ -9,7 +9,7 @@
 Integration tests are opt-in and require running MQ containers:
 
 ```bash
-PYMQREST_RUN_INTEGRATION=1 uv run pytest -m integration
+MQ_REST_ADMIN_RUN_INTEGRATION=1 uv run pytest -m integration
 ```
 
 When enabled, the test session:

--- a/docs/site/docs/examples.md
+++ b/docs/site/docs/examples.md
@@ -138,5 +138,5 @@ Integration tests for all examples are in `tests/integration/test_examples.py`
 and run with:
 
 ```bash
-PYMQREST_RUN_INTEGRATION=1 uv run pytest tests/integration/test_examples.py
+MQ_REST_ADMIN_RUN_INTEGRATION=1 uv run pytest tests/integration/test_examples.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,5 +125,5 @@ minversion = "7.0"
 testpaths = ["tests"]
 addopts = "-v"
 markers = [
-    "integration: integration tests (require PYMQREST_RUN_INTEGRATION=1)",
+    "integration: integration tests (require MQ_REST_ADMIN_RUN_INTEGRATION=1)",
 ]

--- a/scripts/dev/mq_reset.sh
+++ b/scripts/dev/mq_reset.sh
@@ -10,7 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
-export COMPOSE_PROJECT_NAME=pymqrest
+export COMPOSE_PROJECT_NAME=mqrest-python
 
 cd "$mq_dev_env"
 exec scripts/mq_reset.sh

--- a/scripts/dev/mq_seed.sh
+++ b/scripts/dev/mq_seed.sh
@@ -10,7 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
-export COMPOSE_PROJECT_NAME=pymqrest
+export COMPOSE_PROJECT_NAME=mqrest-python
 
 cd "$mq_dev_env"
 exec scripts/mq_seed.sh

--- a/scripts/dev/mq_start.sh
+++ b/scripts/dev/mq_start.sh
@@ -10,7 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
-export COMPOSE_PROJECT_NAME=pymqrest
+export COMPOSE_PROJECT_NAME=mqrest-python
 
 cd "$mq_dev_env"
 exec scripts/mq_start.sh

--- a/scripts/dev/mq_stop.sh
+++ b/scripts/dev/mq_stop.sh
@@ -10,7 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
-export COMPOSE_PROJECT_NAME=pymqrest
+export COMPOSE_PROJECT_NAME=mqrest-python
 
 cd "$mq_dev_env"
 exec scripts/mq_stop.sh

--- a/scripts/dev/mq_verify.sh
+++ b/scripts/dev/mq_verify.sh
@@ -10,7 +10,7 @@ if [ ! -d "$mq_dev_env" ]; then
   exit 1
 fi
 
-export COMPOSE_PROJECT_NAME=pymqrest
+export COMPOSE_PROJECT_NAME=mqrest-python
 
 cd "$mq_dev_env"
 exec scripts/mq_verify.sh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = PROJECT_ROOT / "src"
 SCRIPTS_ROOT = PROJECT_ROOT / "scripts"
-INTEGRATION_ENV_VAR = "PYMQREST_RUN_INTEGRATION"
+INTEGRATION_ENV_VAR = "MQ_REST_ADMIN_RUN_INTEGRATION"
 
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
@@ -29,7 +29,7 @@ def _integration_enabled() -> bool:
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
-        "integration: integration tests (require PYMQREST_RUN_INTEGRATION=1)",
+        "integration: integration tests (require MQ_REST_ADMIN_RUN_INTEGRATION=1)",
     )
 
 

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -15,7 +15,7 @@ from examples.queue_status import report_connection_handles, report_queue_handle
 from pymqrest.auth import BasicAuth
 from pymqrest.session import MQRESTSession
 
-INTEGRATION_ENV_FLAG = "PYMQREST_RUN_INTEGRATION"
+INTEGRATION_ENV_FLAG = "MQ_REST_ADMIN_RUN_INTEGRATION"
 
 pytestmark = [pytest.mark.integration]
 

--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -16,7 +16,7 @@ from pymqrest.ensure import EnsureAction
 from pymqrest.exceptions import MQRESTError
 from pymqrest.session import MQRESTSession
 
-INTEGRATION_ENV_FLAG = "PYMQREST_RUN_INTEGRATION"
+INTEGRATION_ENV_FLAG = "MQ_REST_ADMIN_RUN_INTEGRATION"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MQ_START_SCRIPT = REPO_ROOT / "scripts/dev/mq_start.sh"
 MQ_STOP_SCRIPT = REPO_ROOT / "scripts/dev/mq_stop.sh"


### PR DESCRIPTION
# Pull Request

## Summary

- Standardize gate variable, COMPOSE_PROJECT_NAME, and CI port allocation for cross-repo consistency

## Issue Linkage

- Fixes #402

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -