### PR TITLE
ci: extract type-check into standalone ci: type-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,6 @@ jobs:
       - name: Run ruff format check
         run: uv run ruff format --check .
 
-      - name: Run mypy
-        run: uv run mypy src/
-
-      - name: Run ty
-        run: uv run ty check src
-
       - name: Run tests with coverage
         run: |
           uv run pytest \
@@ -95,6 +89,24 @@ jobs:
             --cov-report=term-missing \
             --cov-branch \
             --cov-fail-under=100
+
+  type-check:
+    name: "ci: type-check"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wphillipmoore/dev-python:3.14
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run mypy
+        run: uv run mypy src/
+
+      - name: Run ty
+        run: uv run ty check src
 
   dependency-audit:
     name: "ci: dependency-audit"


### PR DESCRIPTION
# Pull Request

## Summary

- Extract mypy and ty into standalone ci: type-check job per standard-actions#110

## Issue Linkage

- Fixes #404

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -