### PR TITLE
chore(ports): add explicit port exports to MQ lifecycle scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,12 @@ Container details:
 - QM2 REST base URL: `https://localhost:9444/ibmmq/rest/v2`
 - Object prefix: `DEV.*`
 
+Port assignments are explicit in each `scripts/dev/mq_*.sh` script via
+`QM1_REST_PORT`, `QM2_REST_PORT`, `QM1_MQ_PORT`, and `QM2_MQ_PORT` exports.
+Python uses the base ports (9443/9444, 1414/1415). See the
+[port allocation table](https://github.com/wphillipmoore/mq-rest-admin-common)
+in mq-rest-admin-common for the full cross-language map.
+
 ## Architecture
 
 ### Core Components

--- a/scripts/dev/mq_reset.sh
+++ b/scripts/dev/mq_reset.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME=mqrest-python
+export QM1_REST_PORT=9443
+export QM2_REST_PORT=9444
+export QM1_MQ_PORT=1414
+export QM2_MQ_PORT=1415
 
 cd "$mq_dev_env"
 exec scripts/mq_reset.sh

--- a/scripts/dev/mq_seed.sh
+++ b/scripts/dev/mq_seed.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME=mqrest-python
+export QM1_REST_PORT=9443
+export QM2_REST_PORT=9444
+export QM1_MQ_PORT=1414
+export QM2_MQ_PORT=1415
 
 cd "$mq_dev_env"
 exec scripts/mq_seed.sh

--- a/scripts/dev/mq_start.sh
+++ b/scripts/dev/mq_start.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME=mqrest-python
+export QM1_REST_PORT=9443
+export QM2_REST_PORT=9444
+export QM1_MQ_PORT=1414
+export QM2_MQ_PORT=1415
 
 cd "$mq_dev_env"
 exec scripts/mq_start.sh

--- a/scripts/dev/mq_stop.sh
+++ b/scripts/dev/mq_stop.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME=mqrest-python
+export QM1_REST_PORT=9443
+export QM2_REST_PORT=9444
+export QM1_MQ_PORT=1414
+export QM2_MQ_PORT=1415
 
 cd "$mq_dev_env"
 exec scripts/mq_stop.sh

--- a/scripts/dev/mq_verify.sh
+++ b/scripts/dev/mq_verify.sh
@@ -11,6 +11,10 @@ if [ ! -d "$mq_dev_env" ]; then
 fi
 
 export COMPOSE_PROJECT_NAME=mqrest-python
+export QM1_REST_PORT=9443
+export QM2_REST_PORT=9444
+export QM1_MQ_PORT=1414
+export QM2_MQ_PORT=1415
 
 cd "$mq_dev_env"
 exec scripts/mq_verify.sh


### PR DESCRIPTION
# Pull Request

## Summary

- Add explicit port exports to MQ lifecycle scripts so Python uses documented unique ports

## Issue Linkage

- Fixes #410

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -