### PR TITLE
fix: require name parameter for DELETE Q* methods

### DIFF
--- a/src/pymqrest/commands.py
+++ b/src/pymqrest/commands.py
@@ -1688,7 +1688,7 @@ class MQRESTCommandMixin:
 
     def delete_qalias(
         self,
-        name: str | None = None,
+        name: str,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
@@ -1718,7 +1718,7 @@ class MQRESTCommandMixin:
 
     def delete_qlocal(
         self,
-        name: str | None = None,
+        name: str,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
@@ -1748,7 +1748,7 @@ class MQRESTCommandMixin:
 
     def delete_qmodel(
         self,
-        name: str | None = None,
+        name: str,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:
@@ -1778,7 +1778,7 @@ class MQRESTCommandMixin:
 
     def delete_qremote(
         self,
-        name: str | None = None,
+        name: str,
         request_parameters: Mapping[str, object] | None = None,
         response_parameters: Sequence[str] | None = None,
     ) -> None:

--- a/src/pymqrest/mapping-data.json
+++ b/src/pymqrest/mapping-data.json
@@ -172,16 +172,20 @@
       "qualifier": "psid"
     },
     "DELETE QALIAS": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QLOCAL": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QMODEL": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QREMOTE": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QUEUE": {
       "qualifier": "queue",


### PR DESCRIPTION
# Pull Request

## Summary

- Require name parameter for delete_qlocal, delete_qremote, delete_qalias, and delete_qmodel methods

## Issue Linkage

- Fixes #414

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -