### PR TITLE
fix: LTPA cookie extraction uses prefix matching for suffixed cookie names

### DIFF
--- a/src/pymqrest/auth.py
+++ b/src/pymqrest/auth.py
@@ -80,8 +80,8 @@ def _perform_ltpa_login(
     csrf_token: str | None,
     timeout_seconds: float | None,
     verify_tls: bool,
-) -> str:
-    """Perform an LTPA login and return the ``LtpaToken2`` token value.
+) -> tuple[str, str]:
+    """Perform an LTPA login and return the cookie name and token value.
 
     Args:
         transport: The transport to use for the login POST request.
@@ -92,7 +92,8 @@ def _perform_ltpa_login(
         verify_tls: Whether to verify the server's TLS certificate.
 
     Returns:
-        The ``LtpaToken2`` cookie value string.
+        A ``(cookie_name, token_value)`` tuple. The cookie name may be
+        ``"LtpaToken2"`` or a suffixed variant like ``"LtpaToken2_xyz"``.
 
     Raises:
         MQRESTAuthError: If the login request fails or the response
@@ -120,26 +121,28 @@ def _perform_ltpa_login(
             url=login_url,
             status_code=response.status_code,
         )
-    token = _extract_ltpa_token(response.headers)
-    if token is None:
+    result = _extract_ltpa_token(response.headers)
+    if result is None:
         raise MQRESTAuthError(
             ERROR_LTPA_TOKEN_MISSING,
             url=login_url,
             status_code=response.status_code,
         )
-    return token
+    return result
 
 
-def _extract_ltpa_token(headers: Mapping[str, str]) -> str | None:
-    """Extract the ``LtpaToken2`` value from response ``Set-Cookie`` headers.
+def _extract_ltpa_token(headers: Mapping[str, str]) -> tuple[str, str] | None:
+    """Extract an ``LtpaToken2`` cookie from response ``Set-Cookie`` headers.
 
-    Uses :class:`http.cookies.SimpleCookie` for robust cookie parsing.
+    Matches any cookie whose name equals ``"LtpaToken2"`` or starts with
+    ``"LtpaToken2"`` (e.g. ``"LtpaToken2_abcdef"``), using prefix matching
+    to support Liberty's suffixed cookie names.
 
     Args:
         headers: Response headers mapping.
 
     Returns:
-        The token string, or ``None`` if not found.
+        A ``(cookie_name, token_value)`` tuple, or ``None`` if not found.
 
     """
     set_cookie = headers.get("Set-Cookie") or headers.get("set-cookie")
@@ -147,7 +150,7 @@ def _extract_ltpa_token(headers: Mapping[str, str]) -> str | None:
         return None
     cookie = http.cookies.SimpleCookie()
     cookie.load(set_cookie)
-    morsel = cookie.get(LTPA_COOKIE_NAME)
-    if morsel is not None:
-        return morsel.value
+    for name, morsel in cookie.items():
+        if name.startswith(LTPA_COOKIE_NAME):
+            return (name, morsel.value)
     return None

--- a/src/pymqrest/session.py
+++ b/src/pymqrest/session.py
@@ -18,7 +18,7 @@ from ._mapping_merge import (
     validate_mapping_overrides,
     validate_mapping_overrides_complete,
 )
-from .auth import LTPA_COOKIE_NAME, BasicAuth, CertificateAuth, Credentials, LTPAAuth, _perform_ltpa_login
+from .auth import BasicAuth, CertificateAuth, Credentials, LTPAAuth, _perform_ltpa_login
 from .commands import MQRESTCommandMixin
 from .ensure import MQRESTEnsureMixin
 from .exceptions import (
@@ -282,9 +282,10 @@ class MQRESTSession(MQRESTSyncMixin, MQRESTEnsureMixin, MQRESTCommandMixin):
         else:
             self._transport = transport or RequestsTransport()
 
+        self._ltpa_cookie_name: str | None = None
         self._ltpa_token: str | None = None
         if isinstance(credentials, LTPAAuth):
-            self._ltpa_token = _perform_ltpa_login(
+            self._ltpa_cookie_name, self._ltpa_token = _perform_ltpa_login(
                 self._transport,
                 self._rest_base_url,
                 credentials,
@@ -407,7 +408,7 @@ class MQRESTSession(MQRESTSyncMixin, MQRESTEnsureMixin, MQRESTCommandMixin):
                 self._credentials.password,
             )
         elif isinstance(self._credentials, LTPAAuth) and self._ltpa_token is not None:
-            headers["Cookie"] = f"{LTPA_COOKIE_NAME}={self._ltpa_token}"
+            headers["Cookie"] = f"{self._ltpa_cookie_name}={self._ltpa_token}"
         if self._csrf_token is not None:
             headers["ibm-mq-rest-csrf-token"] = self._csrf_token
         if self._gateway_qmgr is not None:

--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -506,7 +506,6 @@ def test_ensure_channel_lifecycle() -> None:
     session.delete_channel(name=TEST_ENSURE_CHANNEL)
 
 
-@pytest.mark.xfail(reason="MQ developer container does not return LtpaToken2 cookies", strict=False)
 def test_ltpa_auth_display_qmgr() -> None:
     config = load_integration_config()
     session = MQRESTSession(

--- a/tests/pymqrest/test_auth.py
+++ b/tests/pymqrest/test_auth.py
@@ -106,7 +106,7 @@ def test_perform_ltpa_login_success() -> None:
         ),
     )
 
-    token = _perform_ltpa_login(
+    cookie_name, token = _perform_ltpa_login(
         transport,
         "https://example.invalid/ibmmq/rest/v2",
         LTPAAuth("user", TEST_PASSWORD),
@@ -115,11 +115,34 @@ def test_perform_ltpa_login_success() -> None:
         verify_tls=False,
     )
 
+    assert cookie_name == "LtpaToken2"
     assert token == "abc123"
     assert transport.recorded_url == "https://example.invalid/ibmmq/rest/v2/login"
     assert transport.recorded_payload == {"username": "user", "password": TEST_PASSWORD}
     assert transport.recorded_headers is not None
     assert transport.recorded_headers["ibm-mq-rest-csrf-token"] == "local"
+
+
+def test_perform_ltpa_login_success_with_suffixed_cookie() -> None:
+    transport = FakeLoginTransport(
+        TransportResponse(
+            status_code=STATUS_OK,
+            text="",
+            headers={"Set-Cookie": "LtpaToken2_abcdef=suffixed_tok; Path=/; HttpOnly"},
+        ),
+    )
+
+    cookie_name, token = _perform_ltpa_login(
+        transport,
+        "https://example.invalid/ibmmq/rest/v2",
+        LTPAAuth("user", TEST_PASSWORD),
+        csrf_token="local",
+        timeout_seconds=30.0,
+        verify_tls=False,
+    )
+
+    assert cookie_name == "LtpaToken2_abcdef"
+    assert token == "suffixed_tok"
 
 
 def test_perform_ltpa_login_without_csrf_token() -> None:
@@ -131,7 +154,7 @@ def test_perform_ltpa_login_without_csrf_token() -> None:
         ),
     )
 
-    token = _perform_ltpa_login(
+    cookie_name, token = _perform_ltpa_login(
         transport,
         "https://example.invalid/ibmmq/rest/v2",
         LTPAAuth("user", TEST_PASSWORD),
@@ -140,6 +163,7 @@ def test_perform_ltpa_login_without_csrf_token() -> None:
         verify_tls=False,
     )
 
+    assert cookie_name == "LtpaToken2"
     assert token == "token_value"
     assert transport.recorded_headers is not None
     assert "ibm-mq-rest-csrf-token" not in transport.recorded_headers
@@ -219,7 +243,16 @@ def test_perform_ltpa_login_no_set_cookie_raises() -> None:
 
 def test_extract_ltpa_token_with_multiple_cookies() -> None:
     headers = {"Set-Cookie": "Other=x; Path=/, LtpaToken2=multi_tok; Path=/; Secure"}
-    assert _extract_ltpa_token(headers) == "multi_tok"
+    result = _extract_ltpa_token(headers)
+    assert result is not None
+    assert result == ("LtpaToken2", "multi_tok")
+
+
+def test_extract_ltpa_token_with_suffixed_cookie_name() -> None:
+    headers = {"Set-Cookie": "LtpaToken2_xyz123=suffixed_tok; Path=/; Secure"}
+    result = _extract_ltpa_token(headers)
+    assert result is not None
+    assert result == ("LtpaToken2_xyz123", "suffixed_tok")
 
 
 def test_extract_ltpa_token_no_match() -> None:
@@ -238,4 +271,6 @@ def test_extract_ltpa_token_no_headers() -> None:
 
 def test_extract_ltpa_token_lowercase_header() -> None:
     headers = {"set-cookie": "LtpaToken2=lower_tok; Path=/"}
-    assert _extract_ltpa_token(headers) == "lower_tok"
+    result = _extract_ltpa_token(headers)
+    assert result is not None
+    assert result == ("LtpaToken2", "lower_tok")

--- a/tests/pymqrest/test_session.py
+++ b/tests/pymqrest/test_session.py
@@ -1560,6 +1560,41 @@ def test_credentials_ltpa_auth_sends_cookie_header() -> None:
     assert command_request.headers["Cookie"] == "LtpaToken2=ltpa_test_token"
 
 
+def test_credentials_ltpa_auth_with_suffixed_cookie_name() -> None:
+    login_response = TransportResponse(
+        status_code=200,
+        text="",
+        headers={"Set-Cookie": "LtpaToken2_abc123=suffixed_tok; Path=/; HttpOnly"},
+    )
+    command_response = TransportResponse(
+        status_code=200,
+        text=json.dumps(
+            {
+                "commandResponse": [
+                    {"completionCode": 0, "reasonCode": 0, "parameters": {"QMNAME": "QM1"}},
+                ],
+                "overallCompletionCode": 0,
+                "overallReasonCode": 0,
+            },
+        ),
+        headers={},
+    )
+    transport = MultiResponseTransport([login_response, command_response])
+
+    session = MQRESTSession(
+        "https://example.invalid/ibmmq/rest/v2",
+        "QM1",
+        credentials=LTPAAuth("user", TEST_PASSWORD),
+        transport=transport,
+    )
+
+    result = session.display_qmgr()
+
+    assert result == {"queue_manager_name": "QM1"}
+    command_request = transport.recorded_requests[1]
+    assert command_request.headers["Cookie"] == "LtpaToken2_abc123=suffixed_tok"
+
+
 def test_credentials_certificate_auth_no_auth_header() -> None:
     response_payload = {
         "commandResponse": [


### PR DESCRIPTION
# Pull Request

## Summary

- Use prefix matching for LTPA cookie extraction to support Liberty suffixed cookie names

## Issue Linkage

- Fixes #417

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -