### PR TITLE
docs: add cross-repo documentation links to docs site

### DIFF
--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -37,3 +37,5 @@ shapes are stable but may evolve.
 ## License
 
 GNU General Public License v3.0
+
+--8<-- "other-languages.md"


### PR DESCRIPTION
# Pull Request

## Summary

- Add cross-repo documentation links to docs site home page

## Issue Linkage

- Fixes #419

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -