### PR TITLE
test: add session state populated after command integration test

### DIFF
--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -582,6 +582,18 @@ def test_gateway_session_properties() -> None:
     assert session.gateway_qmgr == config.qmgr_name
 
 
+def test_session_state_populated_after_command() -> None:
+    config = load_integration_config()
+    session = _build_session(config)
+
+    session.display_qmgr()
+
+    assert session.last_http_status is not None
+    assert session.last_response_text is not None
+    assert session.last_response_payload is not None
+    assert session.last_command_payload is not None
+
+
 def _require_integration_enabled() -> None:
     if getenv(INTEGRATION_ENV_FLAG) != "1":
         pytest.skip(f"Set {INTEGRATION_ENV_FLAG}=1 to enable integration tests.")


### PR DESCRIPTION
# Pull Request

## Summary

- Add integration test verifying session state properties are populated after executing a command

## Issue Linkage

- Ref #136

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -