### PR TITLE
feat(sync): add SyncConfig construction validation

### DIFF
--- a/src/pymqrest/sync.py
+++ b/src/pymqrest/sync.py
@@ -27,6 +27,15 @@ class SyncConfig:
     timeout_seconds: float = 30.0
     poll_interval_seconds: float = 1.0
 
+    def __post_init__(self) -> None:
+        """Validate that both fields are positive."""
+        if self.timeout_seconds <= 0:
+            msg = f"timeout_seconds must be positive, got {self.timeout_seconds}"
+            raise ValueError(msg)
+        if self.poll_interval_seconds <= 0:
+            msg = f"poll_interval_seconds must be positive, got {self.poll_interval_seconds}"
+            raise ValueError(msg)
+
 
 class SyncOperation(enum.Enum):
     """Operation performed by a synchronous wrapper.

--- a/tests/pymqrest/test_sync.py
+++ b/tests/pymqrest/test_sync.py
@@ -134,6 +134,22 @@ class TestSyncConfig:
         with pytest.raises(AttributeError):
             sync_config.timeout_seconds = 99.0  # type: ignore[misc]
 
+    def test_zero_timeout_raises(self) -> None:
+        with pytest.raises(ValueError, match="timeout_seconds must be positive"):
+            SyncConfig(timeout_seconds=0.0)
+
+    def test_negative_timeout_raises(self) -> None:
+        with pytest.raises(ValueError, match="timeout_seconds must be positive"):
+            SyncConfig(timeout_seconds=-1.0)
+
+    def test_zero_poll_interval_raises(self) -> None:
+        with pytest.raises(ValueError, match="poll_interval_seconds must be positive"):
+            SyncConfig(poll_interval_seconds=0.0)
+
+    def test_negative_poll_interval_raises(self) -> None:
+        with pytest.raises(ValueError, match="poll_interval_seconds must be positive"):
+            SyncConfig(poll_interval_seconds=-1.0)
+
 
 # ---------------------------------------------------------------------------
 # SyncOperation enum


### PR DESCRIPTION
# Pull Request

## Summary

- Reject non-positive timeout_seconds and poll_interval_seconds at SyncConfig construction time

## Issue Linkage

- Fixes #424

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -