### PR TITLE
ci: add concurrency group to ci-push workflow

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -8,6 +8,10 @@ on:
       - 'hotfix/**'
       - 'chore/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write


### PR DESCRIPTION
## Summary

- Add `concurrency` group to `ci-push.yml` so new pushes to the same branch cancel in-flight CI runs
- Uses `github.workflow` + `github.ref` as the group key with `cancel-in-progress: true`

Ref: wphillipmoore/standard-tooling#148
