### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymqrest"
-version = "1.2.1"
+version = "1.2.2"
 description = "Python wrapper for the IBM MQ REST API"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ wheels = [
 
 [[package]]
 name = "pymqrest"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
# Pull Request

## Summary

- Manual version bump to 1.2.2 to unblock develop after partially-failed v1.2.1 publish

## Issue Linkage

- Ref #427

## Testing

- markdownlint
- uv run python3 scripts/dev/validate_local.py

## Notes

- -