### PR TITLE
chore(docs): strip CLAUDE.md boilerplate now covered by plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,89 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Auto-memory policy
-
-**Do NOT use MEMORY.md.** Claude Code's auto-memory feature stores behavioral
-rules outside of version control, making them invisible to code review,
-inconsistent across repos, and unreliable across sessions. All behavioral rules,
-conventions, and workflow instructions belong in managed, version-controlled
-documentation (CLAUDE.md, AGENTS.md, skills, or docs/).
-
-If you identify a pattern, convention, or rule worth preserving:
-
-1. **Stop.** Do not write to MEMORY.md.
-2. **Discuss with the user** what you want to capture and why.
-3. **Together, decide** the correct managed location (CLAUDE.md, a skill file,
-   standards docs, or a new issue to track the gap).
-
-This policy exists because MEMORY.md is per-directory and per-machine — it
-creates divergent agent behavior across the multi-repo environment this project
-operates in. Consistency requires all guidance to live in shared, reviewable
-documentation.
-
-## Shell command policy
-
-**Do NOT use heredocs** (`<<EOF` / `<<'EOF'`) for multi-line arguments to CLI
-tools such as `gh`, `git commit`, or `curl`. Heredocs routinely fail due to
-shell escaping issues with apostrophes, backticks, and special characters.
-Always write multi-line content to a temporary file and pass it via `--body-file`
-or `--file` instead.
-
-## Documentation Strategy
-
-This repository uses two complementary approaches for AI agent guidance:
-
-- **AGENTS.md**: Generic AI agent instructions using include directives to force documentation indexing. Contains canonical standards references, shared skills loading, and user override support.
-- **CLAUDE.md** (this file): Claude Code-specific guidance with prescriptive commands, architecture details, and development workflows optimized for `/init`.
-
-### Integration Approach
-
-**For Claude Code** (`/init` command):
-1. Read CLAUDE.md (this file) first for optimized quick-start guidance
-2. Process include directives to load repository standards
-3. Reference AGENTS.md for shared skills and canonical standards location
-4. Apply layered standards: canonical → project-specific → user overrides
-
-**For other AI agents** (Codex, generic LLMs):
-1. Read AGENTS.md first as the primary entry point
-2. Process include directives to load all referenced documentation
-3. Resolve canonical standards repo path (local or GitHub)
-4. Load shared skills from standards repo
-5. Apply user overrides from `~/AGENTS.md` if present
-
-**Key differences**:
-- **CLAUDE.md**: Prescriptive, command-focused, optimized for `/init`
-- **AGENTS.md**: Declarative, include-directive-driven, forces full documentation indexing
-
-Both files share the same underlying standards via include directives, ensuring consistency across all AI agents working in this repository.
-
-### Best Practices for Dual-File Approach
-
-**What goes in AGENTS.md**:
-- Include directives for documentation indexing
-- Canonical standards repository references
-- Shared skills loading instructions
-- User override mechanisms
-- Minimal, declarative content
-
-**What goes in CLAUDE.md**:
-- Claude Code-specific quick-start commands
-- Detailed architecture and design patterns
-- Implementation notes and common workflows
-- Integration guidance between the two files
-- More verbose, prescriptive content
-
-**What goes in neither (use includes instead)**:
-- Repository standards (keep in `docs/repository-standards.md`)
-- Canonical standards (reference external repo)
-- Project-specific conventions (keep in referenced docs)
-
-**Maintenance strategy**:
-- Update standards in source files, not in AGENTS.md or CLAUDE.md
-- Use include directives to pull in shared content
-- Keep AGENTS.md minimal and CLAUDE.md focused on Claude Code workflows
-- Test both entry points when updating documentation structure
-
 <!-- include: docs/standards-and-conventions.md -->
 <!-- include: docs/repository-standards.md -->
 
@@ -309,25 +226,6 @@ in mq-rest-admin-common for the full cross-language map.
 - `src/pymqrest/commands.py` is generated (methods omit per-method docstrings per ruff config)
 - Generation scripts in `scripts/dev/` regenerate code from `MAPPING_DATA`
 
-## Repository Standards Quick Reference
-
-The include directives at the top of this file load the full repository standards. Key highlights for quick reference:
-
-**Pre-flight Checklist**:
-- Check current branch: `git status -sb`
-- If on `develop`, create `feature/*` branch or get explicit approval
-- Enable git hooks: `git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks`
-
-**Python Invocation**: Always use `uv run python3 <script>`
-
-**Tooling**: `uv` version `0.10.4`
-
-**Code Quality**: Ruff (all rules), mypy (strict), 100% test coverage, Python 3.14+
-
-**Repository Profile**: library, library-release branching, artifact-publishing
-
-See `docs/repository-standards.md` for complete details.
-
 ## Important Implementation Notes
 
 ### MQSC Command Execution
@@ -362,79 +260,12 @@ Mapping can be disabled per-session or per-call with `map_attributes=False`.
 - `DEFINE` and `DELETE` methods raise on errors
 - Error payloads stored on session for diagnostics
 
-## Documentation Indexing Strategy
-
-This repository uses `<!-- include: path/to/file.md -->` directives to force documentation indexing. When you encounter these directives:
-
-1. **Read the referenced files** to understand the full context
-2. **Apply layered standards** in order:
-   - Canonical standards (from `standards-and-conventions` repo)
-   - Project-specific standards (`docs/repository-standards.md`)
-   - User overrides (`~/AGENTS.md` if present)
-3. **Load shared skills** from `<standards-repo-path>/skills/**/SKILL.md`
-
-The include directives appear in:
-- `AGENTS.md` - Includes repository standards and conventions
-- `CLAUDE.md` - Includes same standards for Claude Code
-- `docs/standards-and-conventions.md` - Includes canonical standards reference
-
-This approach ensures all AI agents (Codex, Claude, etc.) have access to the same foundational documentation.
-
-## Documentation Structure
-
-- `README.md` - Project overview and quick start
-- `AGENTS.md` - Generic AI agent instructions with include directives
-- `CLAUDE.md` - This file, Claude Code-specific guidance
-- `docs/mq-rest-wrapper-design.md` - Detailed design document
-- `docs/mq-container-local-dev.md` - Local development with MQ container
-- `docs/repository-standards.md` - Project-specific standards (included from AGENTS.md)
-- `docs/standards-and-conventions.md` - Canonical standards reference (includes external repo)
-
-## Commit and PR Scripts
-
-**NEVER use raw `git commit`** — always use `st-commit`.
-**NEVER use raw `gh pr create`** — always use `st-submit-pr`.
-
-### Committing
-
-```bash
-st-commit --type feat --scope session --message "add retry logic" --agent claude
-st-commit --type fix --message "correct attribute mapping" --agent claude
-```
-
-- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
-- `--message` (required): commit description
-- `--agent` (required): `claude` or `codex` — resolves the correct `Co-Authored-By` identity
-- `--scope` (optional): conventional commit scope
-- `--body` (optional): detailed commit body
-
-### Submitting PRs
-
-```bash
-st-submit-pr --issue 42 --summary "Add retry logic to session"
-st-submit-pr --issue 42 --linkage Ref --summary "Update docs" --docs-only
-```
-
-- `--issue` (required): GitHub issue number (just the number)
-- `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
-- `--title` (optional): PR title (default: most recent commit subject)
-- `--notes` (optional): additional notes
-- `--docs-only` (optional): applies docs-only testing exception
-- `--dry-run` (optional): print generated PR without executing
-
 ## Key References
-
-**Canonical Standards**: https://github.com/wphillipmoore/standards-and-conventions
-- Local path (preferred): `../standards-and-conventions`
-- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
 
 **External Documentation**:
 - IBM MQ 9.4 administrative REST API
 - MQSC command reference
 - PCF command formats
-
-**User Overrides**: `~/AGENTS.md` (optional, applied if present and readable)
 
 ## Temporary Workarounds
 


### PR DESCRIPTION
Fixes #438

Strip boilerplate sections from CLAUDE.md that are now enforced by the standard-tooling plugin hooks and skills. Removes: Auto-memory policy, Shell command policy, Documentation Strategy, Repository Standards Quick Reference, Commit and PR Scripts, Documentation Indexing Strategy, Documentation Structure, and generic Key References. Retains all repo-specific content: Project Overview, Development Commands, Architecture, Important Implementation Notes, Temporary Workarounds, and External Documentation (IBM MQ docs).