### PR TITLE
chore: use .markdownlintignore for lint exclusions

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+releases/
+docs/announcements/

--- a/scripts/dev/validate_docs.py
+++ b/scripts/dev/validate_docs.py
@@ -36,10 +36,9 @@ def gather_default_paths() -> list[str]:
     if docs_root.exists():
         candidates.extend(p for p in docs_root.rglob("*.md") if not (p.parts[1:2] and p.parts[1] in exclude_dirs))
 
-    for filename in ("README.md", "CHANGELOG.md"):
-        path = Path(filename)
-        if path.is_file():
-            candidates.append(path)
+    readme = Path("README.md")
+    if readme.is_file():
+        candidates.append(readme)
 
     unique_paths = sorted(set(candidates))
     return [str(path) for path in unique_paths]


### PR DESCRIPTION
# Pull Request

## Summary

- Add .markdownlintignore (CHANGELOG.md, releases/, docs/announcements/)
- Remove CHANGELOG.md from validate_docs.py gather_default_paths()

## Issue Linkage

- Ref wphillipmoore/mq-rest-admin-common#190

## Testing

- markdownlint
- validate_docs.py

## Notes

- Part of cross-repo rollout across all managed repositories