### PR TITLE
refactor: migrate publish workflow to shared reusable workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,124 +11,59 @@ permissions:
   id-token: write
   pull-requests: write
 
-concurrency:
-  group: publish
-  cancel-in-progress: false
-
 jobs:
   publish:
-    name: "publish: release"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@develop
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: write
+    with:
+      ecosystem: python
+      version-command: >-
+        python3 -c "import tomllib; from pathlib import Path;
+        print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
+      registry-check-command: >-
+        python3 -c "
+        import urllib.request, urllib.error, os;
+        v = os.environ['VERSION'];
+        try:
+            urllib.request.urlopen(f'https://pypi.org/pypi/pymqrest/{v}/json', timeout=30);
+            print('exists')
+        except urllib.error.HTTPError as e:
+            print('not_found' if e.code == 404 else 'error')"
+      build-command: >-
+        python3 -m pip install uv==0.10.4 && uv build --sdist --wheel
+      attestation-subject-path: "dist/*"
+      sbom-output-file: "dist/pymqrest-$VERSION.cdx.json"
+      release-title: pymqrest
+      release-notes: |
+        ## Installation
 
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
+        ```bash
+        pip install pymqrest==$VERSION
+        ```
 
-      - name: Extract version
-        id: version
-        run: |
-          version=$(python3 -c "
-          import tomllib
-          from pathlib import Path
-          print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])
-          ")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+        ## Links
 
-      - name: Check if version already on PyPI
-        id: pypi_check
-        run: |
-          status=$(python3 -c "
-          import urllib.request, urllib.error
-          try:
-              urllib.request.urlopen(
-                  'https://pypi.org/pypi/pymqrest/${{ steps.version.outputs.version }}/json',
-                  timeout=30,
-              )
-              print('exists')
-          except urllib.error.HTTPError as e:
-              print('not_found' if e.code == 404 else 'error')
-          ")
-          echo "status=$status" >> "$GITHUB_OUTPUT"
-
-      - name: Check if tag already exists
-        id: tag_check
-        run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install uv
-        if: steps.tag_check.outputs.exists == 'false'
-        run: python3 -m pip install uv==0.10.4
-
-      - name: Build sdist and wheel
-        if: steps.tag_check.outputs.exists == 'false'
-        run: uv build --sdist --wheel
-
-      - name: Attest build provenance
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/attest-build-provenance@v3
-        with:
-          subject-path: "dist/*"
-
-      - name: Publish to PyPI
-        if: steps.pypi_check.outputs.status == 'not_found'
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-      - name: Generate SBOM
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
-        with:
-          scan-type: sbom
-          output-file: dist/pymqrest-${{ steps.version.outputs.version }}.cdx.json
-
-      - name: Tag and release
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
-        with:
-          version: ${{ steps.version.outputs.version }}
-          release-title: pymqrest
-          release-notes: |
-            ## Installation
-
-            ```bash
-            pip install pymqrest==${{ steps.version.outputs.version }}
-            ```
-
-            ## Links
-
-            - [PyPI](https://pypi.org/project/pymqrest/${{ steps.version.outputs.version }}/)
-            - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-python/)
-          release-artifacts: dist/*
-
-      - name: Generate app token for bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Version bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
-        with:
-          current-version: ${{ steps.version.outputs.version }}
-          version-file: pyproject.toml
-          version-regex: '^(version\s*=\s*\").*(\"\s*)$'
-          version-replacement: '\g<1>{version}\2'
-          version-regex-multiline: "true"
-          develop-version-command: python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"
-          post-bump-command: uv lock --upgrade && uv export --no-hashes -o requirements.txt && uv export --no-hashes --group dev -o requirements-dev.txt
-          extra-files: uv.lock requirements.txt requirements-dev.txt
-          app-token: ${{ steps.app-token.outputs.token }}
-          pr-body-extra: Dependencies are refreshed to their latest compatible versions via `uv lock --upgrade`.
+        - [PyPI](https://pypi.org/project/pymqrest/$VERSION/)
+        - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-python/)
+      release-artifacts: "dist/*"
+      version-file: pyproject.toml
+      version-regex: '^(version\s*=\s*\").*(\"\s*)$'
+      version-replacement: '\g<1>{version}\2'
+      version-regex-multiline: "true"
+      develop-version-command: >-
+        python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"
+      post-bump-command: >-
+        uv lock --upgrade &&
+        uv export --no-hashes -o requirements.txt &&
+        uv export --no-hashes --group dev -o requirements-dev.txt
+      extra-files: uv.lock requirements.txt requirements-dev.txt
+      pr-body-extra: >-
+        Dependencies are refreshed to their latest compatible versions
+        via `uv lock --upgrade`.
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,5 @@
 CHANGELOG.md
 releases/
 docs/announcements/
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Replace per-repo publish.yml with thin caller that delegates to the shared `publish-release.yml` reusable workflow in standard-actions
- All ecosystem-specific behavior is passed as inputs to the shared workflow
- Consistent action refs, step ordering, and SBOM output normalization

Ref wphillipmoore/standard-actions#171

## Test plan

- [ ] Verify CI passes on this branch
- [ ] After standard-actions#171 merges to develop, verify publish workflow runs correctly on next release
- [ ] Confirm idempotency: re-run on existing tag should skip all mutating steps
