### PR TITLE
Container-first validation: remove fallbacks, fill check gaps

### DIFF
--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -2,21 +2,11 @@
 set -euo pipefail
 
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pip-audit -r requirements.txt -r requirements-dev.txt}"
+export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --check --frozen --group dev && uv lock --check && uv run pip-audit -r requirements.txt -r requirements-dev.txt && uv run pip-licenses --allow-only=\"\$(grep -v '^\#' .pip-licenses-allowlist | grep -v '^\$' | paste -sd ';' -)\"}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=pymqrest --cov=examples --cov-report=term-missing --cov-branch --cov-fail-under=100}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -4,19 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run mypy src/ && uv run ty check src}"
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test


### PR DESCRIPTION
## Summary
- Remove fallback `docker run` blocks from all dev scripts
- Add `uv sync --check`, `uv lock --check`, and `pip-licenses` to `audit.sh`
- Require `docker-test` on PATH with clear error message

## Test plan
- [ ] Run `scripts/dev/test.sh` — tests pass in container
- [ ] Run `scripts/dev/audit.sh` — sync check, lock check, pip-audit, pip-licenses all run
- [ ] Verify clear error when `docker-test` not on PATH

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)