### PR TITLE
fix: update validation command references to st-validate-local

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,8 +13,7 @@
 
 ## Testing
 
-- markdownlint
-- uv run python3 scripts/dev/validate_local.py
+- `st-validate-local`
 
 ## Notes
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -35,9 +35,7 @@
 
 ## Local validation
 
-- `uv run python3 scripts/dev/validate_local.py`
-- Docs-only changes: `uv run python3 scripts/dev/validate_docs.py`
-- Docs-only validation requires `markdownlint` on the PATH.
+- `st-validate-local`
 
 ## Linting policy
 


### PR DESCRIPTION
## Summary

- Update documented validation command from non-existent `scripts/dev/validate_local.py` to `st-validate-local`
- Also fix the same stale reference in the PR template

## Issue Linkage

- Fixes #435

## Testing

- `st-validate-local`

## Notes

- The PR template also had the same stale reference, fixed in this PR