### PR TITLE
chore: use st-docker-test instead of legacy docker-test wrapper

### DIFF
--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --check --frozen --group dev && uv lock --check && uv run pip-audit -r requirements.txt -r requirements-dev.txt && uv run pip-licenses --allow-only=\"\$(grep -v '^\#' .pip-licenses-allowlist | grep -v '^\$' | paste -sd ';' -)\"}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=pymqrest --cov=examples --cov-report=term-missing --cov-branch --cov-fail-under=100}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run mypy src/ && uv run ty check src}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test


### PR DESCRIPTION
# Pull Request

## Summary

- Update scripts/dev/*.sh to use st-docker-test instead of legacy docker-test wrapper, and update PATH hint from scripts/bin to .venv/bin.

## Issue Linkage

- Fixes #450

## Testing

- `st-validate-local`

## Notes

- -