### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,17 +18,12 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: wphillipmoore/standard-actions/actions/python/setup@develop
-        with:
-          python-version: "3.14"
-          cache-prefix: "uv-docs"
 
       - name: Install dependencies
         run: uv sync --frozen --group docs


### PR DESCRIPTION
# Pull Request

## Summary

- Switch docs workflow to run inside ghcr.io/wphillipmoore/dev-docs:latest container, removing the separate Python setup step.

## Issue Linkage

- Fixes #446

## Testing

- `st-validate-local`

## Notes

- -