### PR TITLE
chore(ci): migrate standard-actions refs from @develop to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
     permissions:
       contents: read
       security-events: write
@@ -145,7 +145,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: wphillipmoore/standard-actions/actions/python/setup@develop
+        uses: wphillipmoore/standard-actions/actions/python/setup@v1.3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -207,7 +207,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.3
         with:
           head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
           main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv sync --frozen --group docs
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
         with:
           version-command: uv run python -c "from importlib.metadata import version; v=version('pymqrest'); print('.'.join(v.split('.')[:2]))"
           mike-command: uv run mike

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.3
     permissions:
       attestations: write
       contents: write


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate standard-actions refs from @develop to @v1.3

## Issue Linkage

- Closes #460

## Testing

- `st-validate-local`

## Notes

- Pins all standard-actions refs to @v1.3 rolling minor tag. Tracking: standard-actions#145. Note: separate PR #457 (delete ci-push.yml) is open against this repo, currently blocked on pip CVE-2026-3219 in dev images. This migration PR is independent of that and can land regardless.