### PR TITLE
chore: seed standard-tooling.toml

### DIFF
--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -1,0 +1,13 @@
+[project]
+repository-type = "library"
+versioning-scheme = "library"
+branching-model = "library-release"
+release-model = "artifact-publishing"
+primary-language = "python"
+
+[project.co-authors]
+claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
+codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+
+[dependencies]
+standard-tooling = "v1.4"


### PR DESCRIPTION
Ref #464

Phase 1 of the standard-tooling.toml migration. Adds the configuration file with this repo's values. The current validator ignores this file; it will be consumed after the next standard-tooling release.