### PR TITLE
chore: add standard-tooling as dev dependency

### DIFF
--- a/.pip-licenses-allowlist
+++ b/.pip-licenses-allowlist
@@ -6,6 +6,7 @@ Apache Software License
 BSD License
 BSD-2-Clause
 BSD-3-Clause
+GPL-3.0-only
 GPL-3.0-or-later
 MIT
 MIT License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pip-audit",
     "pip-licenses",
     "types-requests",
+    "standard-tooling",
 ]
 docs = [
     "mike",
@@ -127,3 +128,6 @@ addopts = "-v"
 markers = [
     "integration: integration tests (require MQ_REST_ADMIN_RUN_INTEGRATION=1)",
 ]
+
+[tool.uv.sources]
+standard-tooling = { git = "https://github.com/wphillipmoore/standard-tooling", tag = "v1.4" }

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -1,0 +1,13 @@
+[project]
+repository-type = "library"
+versioning-scheme = "library"
+branching-model = "library-release"
+release-model = "artifact-publishing"
+primary-language = "python"
+
+[project.co-authors]
+claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
+codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+
+[dependencies]
+standard-tooling = "v1.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <4.0"
 
 [[package]]
@@ -910,6 +910,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "standard-tooling" },
     { name = "ty" },
     { name = "types-requests" },
 ]
@@ -930,6 +931,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "standard-tooling", git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.4" },
     { name = "ty" },
     { name = "types-requests" },
 ]
@@ -1118,6 +1120,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f233
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
+
+[[package]]
+name = "standard-tooling"
+version = "1.4.4"
+source = { git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.4#6832b9967cd1fd8fcba62d773fb6edb59cc41ad8" }
 
 [[package]]
 name = "tomli"

--- a/uv.lock
+++ b/uv.lock
@@ -1123,8 +1123,8 @@ wheels = [
 
 [[package]]
 name = "standard-tooling"
-version = "1.4.4"
-source = { git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.4#6832b9967cd1fd8fcba62d773fb6edb59cc41ad8" }
+version = "1.4.6"
+source = { git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.4#da0e574fe55554df4964899eef033cc3df76bd57" }
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
# Pull Request

## Summary

- Add standard-tooling as a dev dependency so that ci-security.yml can install it via uv sync --group dev. Without this, st-pr-issue-linkage is not on PATH during the standards-compliance CI job.

## Issue Linkage

- Ref #408

## Testing

- `st-validate-local`

## Notes

- -