### PR TITLE
chore(ci): replace retired dev-docs image with dev-base in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-docs:latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- The dev-docs container image was retired — docs tooling has been consolidated into the language-specific dev images. This updates the docs workflow to use dev-base:latest.

## Issue Linkage

- Ref #471

## Testing

- `st-validate-local`

## Notes

- Part of wphillipmoore/standard-tooling#430