### PR TITLE
chore(ci): upgrade to standard-actions v1.5 and enable config enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,9 +149,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: wphillipmoore/standard-actions/actions/python/setup@v1.5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: "true"
 
       - name: Install dependencies
         run: uv sync --frozen --group dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,12 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      python-versions:
-        type: string
-        default: '["3.12", "3.13", "3.14"]'
-      integration-matrix:
-        type: string
-        default: '[{"python-version":"3.12","project-suffix":"3-12","qm1-rest-port":"9447","qm2-rest-port":"9448","qm1-mq-port":"1416","qm2-mq-port":"1417"},{"python-version":"3.13","project-suffix":"3-13","qm1-rest-port":"9449","qm2-rest-port":"9450","qm1-mq-port":"1418","qm2-mq-port":"1419"},{"python-version":"3.14","project-suffix":"3-14","qm1-rest-port":"9451","qm2-rest-port":"9452","qm1-mq-port":"1420","qm2-mq-port":"1421"}]'
       run-security:
-        type: string
-        default: 'true'
-      run-release-gates:
-        type: string
-        default: 'true'
+        type: boolean
+        default: true
+      run-release:
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -27,30 +21,63 @@ concurrency:
 jobs:
 
   # ---------------------------------------------------------------------------
-  # Security and standards (shared reusable workflow)
+  # Quality
   # ---------------------------------------------------------------------------
 
-  security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
-    permissions:
-      contents: read
-      security-events: write
+  quality:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
     with:
       language: python
-      run-standards: ${{ inputs.run-release-gates || 'true' }}
-      run-security: ${{ inputs.run-security || 'true' }}
+      versions: '["3.12", "3.13", "3.14"]'
 
-  # ---------------------------------------------------------------------------
-  # Quality: unit tests, linting, type-checking, dependency audit
-  # ---------------------------------------------------------------------------
-
-  unit-tests:
-    name: "test: unit (${{ matrix.python-version }})"
+  lint:
+    name: "quality / lint / ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python-versions || '["3.12", "3.13", "3.14"]') }}
+        python-version: ["3.12", "3.13", "3.14"]
+    container:
+      image: ghcr.io/wphillipmoore/dev-python:${{ matrix.python-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Lint
+        run: uv run ruff check
+
+      - name: Format check
+        run: uv run ruff format --check .
+
+  typecheck:
+    name: "quality / typecheck / ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    container:
+      image: ghcr.io/wphillipmoore/dev-python:${{ matrix.python-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Type check
+        run: uv run mypy src/
+
+  test:
+    name: "test / unit / ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
     container:
       image: ghcr.io/wphillipmoore/dev-python:${{ matrix.python-version }}
     steps:
@@ -60,29 +87,10 @@ jobs:
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Fetch base branch for version checks
-        if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }} --depth=1
-
-      - name: Validate version string policy
-        run: python3 scripts/dev/validate_version.py
-
-      - name: Validate dependency specifications
-        run: python3 scripts/dev/validate_dependency_specs.py
-
-      - name: Verify uv.lock sync
-        run: uv lock --check
-
       - name: Install dependencies
         run: uv sync --frozen --group dev
 
-      - name: Run ruff check
-        run: uv run ruff check
-
-      - name: Run ruff format check
-        run: uv run ruff format --check .
-
-      - name: Run tests with coverage
+      - name: Tests
         run: |
           uv run pytest \
             --cov=pymqrest \
@@ -91,61 +99,57 @@ jobs:
             --cov-branch \
             --cov-fail-under=100
 
-  type-check:
-    name: "ci: type-check"
+  audit:
+    name: "audit / dependencies / ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
     container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
+      image: ghcr.io/wphillipmoore/dev-python:${{ matrix.python-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install dependencies
-        run: uv sync --frozen --group dev
-
-      - name: Run mypy
-        run: uv run mypy src/
-
-      - name: Run ty
-        run: uv run ty check src
-
-  dependency-audit:
-    name: "ci: dependency-audit"
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: uv sync --frozen --group dev
-
-      - name: Run pip-audit (fail on any vulnerability)
-        run: uv run pip-audit -r requirements.txt -r requirements-dev.txt
-
-      - name: Run pip-licenses (license compliance)
-        run: >-
-          uv run pip-licenses
-          --allow-only="$(grep -v '^#' .pip-licenses-allowlist | grep -v '^$' | paste -sd ';' -)"
+      - name: Check lockfile integrity
+        run: uv lock --check
 
   # ---------------------------------------------------------------------------
   # Integration tests
   # ---------------------------------------------------------------------------
 
   integration-tests:
-    name: "test: integration (${{ matrix.python-version }})"
+    name: "test / integration / ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(inputs.integration-matrix || '[{"python-version":"3.12","project-suffix":"3-12","qm1-rest-port":"9447","qm2-rest-port":"9448","qm1-mq-port":"1416","qm2-mq-port":"1417"},{"python-version":"3.13","project-suffix":"3-13","qm1-rest-port":"9449","qm2-rest-port":"9450","qm1-mq-port":"1418","qm2-mq-port":"1419"},{"python-version":"3.14","project-suffix":"3-14","qm1-rest-port":"9451","qm2-rest-port":"9452","qm1-mq-port":"1420","qm2-mq-port":"1421"}]') }}
+        include:
+          - python-version: "3.12"
+            project-suffix: "3-12"
+            qm1-rest-port: "9447"
+            qm2-rest-port: "9448"
+            qm1-mq-port: "1416"
+            qm2-mq-port: "1417"
+          - python-version: "3.13"
+            project-suffix: "3-13"
+            qm1-rest-port: "9449"
+            qm2-rest-port: "9450"
+            qm1-mq-port: "1418"
+            qm2-mq-port: "1419"
+          - python-version: "3.14"
+            project-suffix: "3-14"
+            qm1-rest-port: "9451"
+            qm2-rest-port: "9452"
+            qm1-mq-port: "1420"
+            qm2-mq-port: "1421"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: wphillipmoore/standard-actions/actions/python/setup@v1.4
+        uses: wphillipmoore/standard-actions/actions/python/setup@v1.5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -171,12 +175,26 @@ jobs:
           uv run pytest -m integration
 
   # ---------------------------------------------------------------------------
-  # Release gates (PR only)
+  # Security and standards
   # ---------------------------------------------------------------------------
 
-  release-gates:
-    name: "release: gates"
-    if: ${{ inputs.run-release-gates != 'false' }}
+  security:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    with:
+      language: python
+      run-standards: ${{ inputs.run-release || true }}
+      run-security: ${{ inputs.run-security || true }}
+    permissions:
+      contents: read
+      security-events: write
+
+  # ---------------------------------------------------------------------------
+  # Release
+  # ---------------------------------------------------------------------------
+
+  release:
+    name: "release / version-bump"
+    if: ${{ inputs.run-release != false }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/wphillipmoore/dev-python:3.14
@@ -195,19 +213,9 @@ jobs:
         if: github.event_name == 'pull_request'
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: PyPI version gates (PRs targeting main)
-        if: github.event_name == 'pull_request' && github.base_ref == 'main'
-        run: |
-          python3 scripts/dev/validate_pypi_version.py --check-not-exists
-          python3 scripts/dev/validate_pypi_version.py --check-greater-than-latest
-
-      - name: Changelog version gate (PRs targeting main)
-        if: github.event_name == 'pull_request' && github.base_ref == 'main'
-        run: python3 scripts/dev/validate_changelog.py
-
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.4
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.5
         with:
           head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
           main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv sync --frozen --group docs
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
         with:
           version-command: uv run python -c "from importlib.metadata import version; v=version('pymqrest'); print('.'.join(v.split('.')[:2]))"
           mike-command: uv run mike

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.4
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     permissions:
       attestations: write
       contents: write

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,5 +9,9 @@ primary-language = "python"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[ci]
+versions = ["3.12", "3.13", "3.14"]
+integration-tests = true
+
 [dependencies]
 standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Upgrade all workflow action references from v1.4 to v1.5, split CI into named jobs matching derived check convention, rename integration tests to derived gate names, and add [ci] section to standard-tooling.toml. Removed bespoke validate_version, validate_changelog, validate_dependency_specs, validate_pypi_version, pip-audit, pip-licenses, and ty steps — tracked for centralization in standard-tooling #526, #527, #528, #531, #532.

## Issue Linkage

- Ref #173

## Testing

- `st-validate-local`

## Notes

- -