### PR TITLE
ci: adopt standard-actions v1.5 reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         run: uv sync --frozen --group dev
 
       - name: Setup MQ environment
+        # yamllint disable-line rule:line-length
         uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           project-name: mqrest-python-${{ matrix.project-suffix }}
@@ -94,8 +95,10 @@ jobs:
 
       - name: Run integration tests
         env:
-          MQ_REST_BASE_URL: https://localhost:${{ matrix.qm1-rest-port }}/ibmmq/rest/v2
-          MQ_REST_BASE_URL_QM2: https://localhost:${{ matrix.qm2-rest-port }}/ibmmq/rest/v2
+          MQ_REST_BASE_URL: >-
+            https://localhost:${{ matrix.qm1-rest-port }}/ibmmq/rest/v2
+          MQ_REST_BASE_URL_QM2: >-
+            https://localhost:${{ matrix.qm2-rest-port }}/ibmmq/rest/v2
         run: |
           MQ_SKIP_LIFECYCLE=1 \
           MQ_REST_ADMIN_RUN_INTEGRATION=1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.5
     with:
       language: python
-      versions: '["3.14"]'
+      versions: '["3.12", "3.13", "3.14"]'
 
   # ---------------------------------------------------------------------------
   # Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,90 +30,17 @@ jobs:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
 
-  lint:
-    name: "quality / lint / ${{ matrix.python-version }}"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:${{ matrix.python-version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: uv sync --frozen --group dev
-
-      - name: Lint
-        run: uv run ruff check
-
-      - name: Format check
-        run: uv run ruff format --check .
-
-  typecheck:
-    name: "quality / typecheck / ${{ matrix.python-version }}"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:${{ matrix.python-version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: uv sync --frozen --group dev
-
-      - name: Type check
-        run: uv run mypy src/
-
   test:
-    name: "test / unit / ${{ matrix.python-version }}"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:${{ matrix.python-version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Mark workspace safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Install dependencies
-        run: uv sync --frozen --group dev
-
-      - name: Tests
-        run: |
-          uv run pytest \
-            --cov=pymqrest \
-            --cov=examples \
-            --cov-report=term-missing \
-            --cov-branch \
-            --cov-fail-under=100
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
 
   audit:
-    name: "audit / dependencies / ${{ matrix.python-version }}"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:${{ matrix.python-version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Check lockfile integrity
-        run: uv lock --check
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.5
+    with:
+      language: python
+      versions: '["3.14"]'
 
   # ---------------------------------------------------------------------------
   # Integration tests
@@ -193,29 +120,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   release:
-    name: "release / version-bump"
-    if: ${{ inputs.run-release != false }}
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Skip on non-PR events
-        if: github.event_name != 'pull_request'
-        run: echo "Not a pull request; skipping release gates."
-
-      - name: Checkout code
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Mark workspace safe for git
-        if: github.event_name == 'pull_request'
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Version divergence gate (PRs targeting develop)
-        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.5
-        with:
-          head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
-          main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-release.yml@v1.5
+    with:
+      language: python
+      run-release: ${{ inputs.run-release != false }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Deploy docs
         uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
         with:
-          version-command: uv run python -c "from importlib.metadata import version; v=version('pymqrest'); print('.'.join(v.split('.')[:2]))"
+          version-command: st-version show --major-minor
           mike-command: uv run mike
           checkout-common: "true"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   publish:
+    # yamllint disable-line rule:line-length
     uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     permissions:
       attestations: write
@@ -21,15 +22,14 @@ jobs:
       pull-requests: write
     with:
       ecosystem: python
-      version-command: >-
-        python3 -c "import tomllib; from pathlib import Path;
-        print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
+      version-command: st-version show
       registry-check-command: >-
         python3 -c "
         import urllib.request, urllib.error, os;
         v = os.environ['VERSION'];
         try:
-            urllib.request.urlopen(f'https://pypi.org/pypi/pymqrest/{v}/json', timeout=30);
+            u = f'https://pypi.org/pypi/pymqrest/{v}/json';
+            urllib.request.urlopen(u, timeout=30);
             print('exists')
         except urllib.error.HTTPError as e:
             print('not_found' if e.code == 404 else 'error')"
@@ -54,8 +54,7 @@ jobs:
       version-regex: '^(version\s*=\s*\").*(\"\s*)$'
       version-replacement: '\g<1>{version}\2'
       version-regex-multiline: "true"
-      develop-version-command: >-
-        python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"
+      develop-version-command: st-version show
       post-bump-command: >-
         uv lock --upgrade &&
         uv export --no-hashes -o requirements.txt &&

--- a/tests/integration/test_mq_integration.py
+++ b/tests/integration/test_mq_integration.py
@@ -8,8 +8,12 @@ import time
 from dataclasses import dataclass
 from os import getenv
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from pymqrest.auth import BasicAuth, LTPAAuth
 from pymqrest.ensure import EnsureAction
@@ -255,7 +259,7 @@ def _skip_lifecycle() -> bool:
 
 
 @pytest.fixture(scope="session")
-def integration_environment() -> None:
+def integration_environment() -> Iterator[None]:
     _require_integration_enabled()
     if not _skip_lifecycle():
         _run_script(MQ_START_SCRIPT)
@@ -672,11 +676,11 @@ def _display_contains_value(result: object, expected_value: str) -> bool:
 
 def _find_matching_object(result: object, expected_value: str) -> dict[str, object] | None:
     if isinstance(result, dict):
-        return result if _contains_string_value(result, expected_value) else None
+        return result if _contains_string_value(result, expected_value) else None  # ty: ignore[invalid-return-type,invalid-argument-type]
     if isinstance(result, list):
         for item in result:
-            if isinstance(item, dict) and _contains_string_value(item, expected_value):
-                return item
+            if isinstance(item, dict) and _contains_string_value(item, expected_value):  # ty: ignore[invalid-argument-type]
+                return item  # ty: ignore[invalid-return-type]
     return None
 
 

--- a/tests/pymqrest/test_mapping_merge.py
+++ b/tests/pymqrest/test_mapping_merge.py
@@ -102,7 +102,7 @@ def test_merge_does_not_mutate_base() -> None:
         "commands": {"DISPLAY QUEUE": {"qualifier": "queue"}},
         "qualifiers": {"queue": {"request_key_map": {"foo": "FOO"}}},
     }
-    original_commands = dict(base["commands"])  # type: ignore[arg-type]
+    original_commands = dict(base["commands"])
 
     merge_mapping_data(base, {"commands": {"DISPLAY QUEUE": {"description": "override"}}})
 

--- a/tests/pymqrest/test_session.py
+++ b/tests/pymqrest/test_session.py
@@ -458,7 +458,7 @@ def test_requests_transport_wraps_request_exception() -> None:
         def post(self, *_args: object, **_kwargs: object) -> object:
             raise RequestException(REQUEST_EXCEPTION_MESSAGE)
 
-    transport = RequestsTransport(FailingSession())
+    transport = RequestsTransport(FailingSession())  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(MQRESTTransportError) as excinfo:
         transport.post_json(
@@ -676,7 +676,7 @@ def test_requests_transport_success() -> None:
             return FakeResponse()
 
     requests_session = RecordingSession()
-    transport = RequestsTransport(requests_session)
+    transport = RequestsTransport(requests_session)  # ty: ignore[invalid-argument-type]
 
     response = transport.post_json(
         "https://example.invalid",
@@ -809,7 +809,7 @@ def test_display_queue_where_none_omits_where_parameter() -> None:
     session.display_queue()
 
     recorded_request = transport.recorded_requests[0]
-    assert "WHERE" not in recorded_request.payload.get("parameters", {})
+    assert "WHERE" not in recorded_request.payload.get("parameters", {})  # ty: ignore[unsupported-operator]
 
 
 def test_display_queue_where_empty_string_is_noop() -> None:
@@ -823,7 +823,7 @@ def test_display_queue_where_empty_string_is_noop() -> None:
     session.display_queue(where="")
 
     recorded_request = transport.recorded_requests[0]
-    assert "WHERE" not in recorded_request.payload.get("parameters", {})
+    assert "WHERE" not in recorded_request.payload.get("parameters", {})  # ty: ignore[unsupported-operator]
 
 
 def test_display_queue_where_combined_with_request_parameters() -> None:
@@ -841,8 +841,8 @@ def test_display_queue_where_combined_with_request_parameters() -> None:
 
     recorded_request = transport.recorded_requests[0]
     params = recorded_request.payload["parameters"]
-    assert params["WHERE"] == "CURDEPTH GT 100"
-    assert params["DEFPSIST"] == "DEF"
+    assert params["WHERE"] == "CURDEPTH GT 100"  # ty: ignore[not-subscriptable]
+    assert params["DEFPSIST"] == "DEF"  # ty: ignore[not-subscriptable]
 
 
 def test_display_queue_where_overrides_request_parameters_where() -> None:
@@ -869,7 +869,7 @@ def test_display_queue_where_overrides_request_parameters_where() -> None:
     )
 
     recorded_request = transport.recorded_requests[0]
-    assert recorded_request.payload["parameters"]["WHERE"] == "CURDEPTH GT 100"
+    assert recorded_request.payload["parameters"]["WHERE"] == "CURDEPTH GT 100"  # ty: ignore[not-subscriptable]
 
 
 def test_display_channel_where_maps_filter_keyword() -> None:
@@ -883,7 +883,7 @@ def test_display_channel_where_maps_filter_keyword() -> None:
     session.display_channel(where="channel_type EQ SVRCONN")
 
     recorded_request = transport.recorded_requests[0]
-    assert recorded_request.payload["parameters"]["WHERE"] == "CHLTYPE EQ SVRCONN"
+    assert recorded_request.payload["parameters"]["WHERE"] == "CHLTYPE EQ SVRCONN"  # ty: ignore[not-subscriptable]
 
 
 def test_map_where_keyword_unknown_qualifier_strict_raises() -> None:
@@ -1324,7 +1324,7 @@ def test_mapping_overrides_request_key_override() -> None:
     session.display_queue(request_parameters={"my_depth": TEST_DEPTH})
 
     recorded_request = transport.recorded_requests[0]
-    assert recorded_request.payload["parameters"]["CURDEPTH"] == TEST_DEPTH
+    assert recorded_request.payload["parameters"]["CURDEPTH"] == TEST_DEPTH  # ty: ignore[not-subscriptable]
 
 
 def test_mapping_overrides_where_keyword_uses_override() -> None:
@@ -1347,7 +1347,7 @@ def test_mapping_overrides_where_keyword_uses_override() -> None:
     session.display_queue(where="my_depth GT 100")
 
     recorded_request = transport.recorded_requests[0]
-    assert recorded_request.payload["parameters"]["WHERE"] == "CURDEPTH GT 100"
+    assert recorded_request.payload["parameters"]["WHERE"] == "CURDEPTH GT 100"  # ty: ignore[not-subscriptable]
 
 
 def test_mapping_overrides_replace_mode_uses_override_data() -> None:
@@ -1356,7 +1356,7 @@ def test_mapping_overrides_replace_mode_uses_override_data() -> None:
     assert isinstance(base_commands, dict)
     assert isinstance(base_qualifiers, dict)
 
-    custom_qualifiers: dict[str, object] = {
+    custom_qualifiers: dict[str, object] = {  # ty: ignore[invalid-assignment]
         key: dict(value) if isinstance(value, dict) else value for key, value in base_qualifiers.items()
     }
     custom_qualifiers["queue"] = {
@@ -1470,7 +1470,7 @@ def test_mapping_overrides_does_not_affect_unmapped_keys() -> None:
 def _load_mqsc_commands() -> list[str]:
     commands = MAPPING_DATA.get("commands", {})
     assert isinstance(commands, dict)
-    return sorted(commands.keys())
+    return sorted(commands.keys())  # ty: ignore[invalid-argument-type]
 
 
 def _method_name_from_mqsc(command: str) -> str:
@@ -1627,7 +1627,7 @@ def test_credentials_certificate_auth_no_auth_header() -> None:
 
 def test_no_credentials_raises_type_error() -> None:
     with pytest.raises(TypeError, match="credentials"):
-        MQRESTSession(
+        MQRESTSession(  # ty: ignore[missing-argument]
             "https://example.invalid/ibmmq/rest/v2",
             "QM1",
         )
@@ -1657,7 +1657,7 @@ def test_requests_transport_client_cert_configured() -> None:
             self.cert: tuple[str, str] | str | None = None
 
     requests_session = RecordingSession()
-    transport = RequestsTransport(requests_session, client_cert=("/cert.pem", "/key.pem"))
+    transport = RequestsTransport(requests_session, client_cert=("/cert.pem", "/key.pem"))  # ty: ignore[invalid-argument-type]
 
     assert requests_session.cert == ("/cert.pem", "/key.pem")
     _ = transport
@@ -1669,7 +1669,7 @@ def test_requests_transport_client_cert_single_file() -> None:
             self.cert: tuple[str, str] | str | None = None
 
     requests_session = RecordingSession()
-    transport = RequestsTransport(requests_session, client_cert="/combined.pem")
+    transport = RequestsTransport(requests_session, client_cert="/combined.pem")  # ty: ignore[invalid-argument-type]
 
     assert requests_session.cert == "/combined.pem"
     _ = transport


### PR DESCRIPTION
# Pull Request

## Summary

- Replace bespoke CI jobs with standard-actions v1.5 reusable workflows

## Issue Linkage

- Ref #483

## Testing

- `st-validate-local`

## Notes

- ## Changes

- **Add `ci-quality.yml@v1.5`** — replaces bespoke lint (ruff check/format) and typecheck (mypy/ty) jobs with reusable workflow across 3.12/3.13/3.14 matrix
- **Add `ci-test.yml@v1.5`** — replaces bespoke unit test job (pytest with coverage) across 3.12/3.13/3.14 matrix
- **Add `ci-audit.yml@v1.5`** — replaces bespoke dependency audit job (pip-audit, pip-licenses, uv lock --check)
- **Add `ci-release.yml@v1.5`** — version-divergence gate via `st-version show`, replaces inline Python version extraction
- **Update `ci-security.yml` from `@v1.4` to `@v1.5`** — fix string-quoted booleans to proper boolean type
- **Update `python/setup` from `@v1.4` to `@v1.5`** in integration tests
- **Keep bespoke jobs**: integration-tests (MQ docker environment), repo-specific validation scripts (validate_version.py, validate_dependency_specs.py), PyPI/changelog release gates
- **Rename inputs**: `run-release-gates` → `run-release`, `run-security` string → boolean
- **Rename job display names** to follow `category / name` convention