### PR TITLE
chore(templates): shorten issue template header comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# Canonical source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/config.yml
-# Do not modify repo-local copies — update the canonical source and re-sync.
+# Source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/config.yml
+# Do not modify repo-local copies — update the source and re-sync.
 #
 blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,5 +1,5 @@
-# Canonical source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/issue.yml
-# Do not modify repo-local copies — update the canonical source and re-sync.
+# Source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/issue.yml
+# Do not modify repo-local copies — update the source and re-sync.
 #
 name: Issue
 description: Track work with explicit acceptance criteria.


### PR DESCRIPTION
# Pull Request

## Summary

- Remove word canonical from template headers to fix yamllint line-length

## Issue Linkage

- Ref wphillipmoore/standard-tooling#626

## Testing

- `st-docker-run -- st-validate`

## Notes

- Follow-up to fleet cleanup (#626). Header comments exceeded 80-char yamllint limit.