### PR TITLE
fix(docs): update stale wphillipmoore references

### DIFF
--- a/docs/site/docs/development/release-workflow.md
+++ b/docs/site/docs/development/release-workflow.md
@@ -124,8 +124,8 @@ trusted publishing on PyPI:
 1. Go to <https://pypi.org/manage/account/publishing/>.
 2. Add a pending publisher:
    - **Project name**: `pymqrest`
-   - **Owner**: `wphillipmoore`
-   - **Repository**: `pymqrest`
+   - **Owner**: `mq-rest-admin-project`
+   - **Repository**: `mq-rest-admin-python`
    - **Workflow name**: `publish.yml`
    - **Environment**: (leave blank)
 3. The first publish will claim the package name.

--- a/scripts/dev/docs-setup.sh
+++ b/scripts/dev/docs-setup.sh
@@ -25,7 +25,7 @@ fi
 
 if [ ! -d "$COMMON_REPO" ]; then
     echo "Error: Common repo not found at $COMMON_REPO"
-    echo "Clone it with: git clone https://github.com/wphillipmoore/mq-rest-admin-common.git $COMMON_REPO"
+    echo "Clone it with: git clone https://github.com/mq-rest-admin-project/mq-rest-admin-common.git $COMMON_REPO"
     exit 1
 fi
 

--- a/src/pymqrest/commands.py
+++ b/src/pymqrest/commands.py
@@ -48,7 +48,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `authinfo attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/authinfo.html>`__.
+        See `authinfo attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/authinfo.html>`__.
 
         Args:
             name: Object name.
@@ -109,7 +109,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cfstruct attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
+        See `cfstruct attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
 
         Args:
             name: Object name.
@@ -140,7 +140,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -171,7 +171,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `comminfo attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/comminfo.html>`__.
+        See `comminfo attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/comminfo.html>`__.
 
         Args:
             name: Object name.
@@ -202,7 +202,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `listener attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/listener.html>`__.
+        See `listener attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/listener.html>`__.
 
         Args:
             name: Object name.
@@ -233,7 +233,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `namelist attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/namelist.html>`__.
+        See `namelist attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/namelist.html>`__.
 
         Args:
             name: Object name.
@@ -264,7 +264,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `process attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/process.html>`__.
+        See `process attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/process.html>`__.
 
         Args:
             name: Object name.
@@ -325,7 +325,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -356,7 +356,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -386,7 +386,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -416,7 +416,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -447,7 +447,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -478,7 +478,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `security attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/security.html>`__.
+        See `security attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/security.html>`__.
 
         Args:
             name: Object name.
@@ -509,7 +509,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `service attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/service.html>`__.
+        See `service attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/service.html>`__.
 
         Args:
             name: Object name.
@@ -540,7 +540,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `smds attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/smds.html>`__.
+        See `smds attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/smds.html>`__.
 
         Args:
             name: Object name.
@@ -571,7 +571,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `stgclass attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/stgclass.html>`__.
+        See `stgclass attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/stgclass.html>`__.
 
         Args:
             name: Object name.
@@ -602,7 +602,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `sub attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/sub.html>`__.
+        See `sub attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/sub.html>`__.
 
         Args:
             name: Object name.
@@ -633,7 +633,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `topic attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/topic.html>`__.
+        See `topic attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/topic.html>`__.
 
         Args:
             name: Object name.
@@ -694,7 +694,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `log attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/log.html>`__.
+        See `log attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/log.html>`__.
 
         Args:
             name: Object name.
@@ -725,7 +725,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cfstruct attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
+        See `cfstruct attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
 
         Args:
             name: Object name.
@@ -756,7 +756,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -787,7 +787,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `topicstr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/topicstr.html>`__.
+        See `topicstr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/topicstr.html>`__.
 
         Args:
             name: Object name.
@@ -818,7 +818,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `authinfo attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/authinfo.html>`__.
+        See `authinfo attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/authinfo.html>`__.
 
         Args:
             name: Object name.
@@ -879,7 +879,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cfstruct attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
+        See `cfstruct attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
 
         Args:
             name: Object name.
@@ -910,7 +910,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -941,7 +941,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `comminfo attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/comminfo.html>`__.
+        See `comminfo attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/comminfo.html>`__.
 
         Args:
             name: Object name.
@@ -972,7 +972,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `listener attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/listener.html>`__.
+        See `listener attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/listener.html>`__.
 
         Args:
             name: Object name.
@@ -1003,7 +1003,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `log attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/log.html>`__.
+        See `log attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/log.html>`__.
 
         Args:
             name: Object name.
@@ -1064,7 +1064,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `namelist attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/namelist.html>`__.
+        See `namelist attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/namelist.html>`__.
 
         Args:
             name: Object name.
@@ -1095,7 +1095,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `process attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/process.html>`__.
+        See `process attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/process.html>`__.
 
         Args:
             name: Object name.
@@ -1156,7 +1156,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1187,7 +1187,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1218,7 +1218,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1249,7 +1249,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1280,7 +1280,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `service attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/service.html>`__.
+        See `service attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/service.html>`__.
 
         Args:
             name: Object name.
@@ -1311,7 +1311,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `stgclass attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/stgclass.html>`__.
+        See `stgclass attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/stgclass.html>`__.
 
         Args:
             name: Object name.
@@ -1342,7 +1342,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `sub attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/sub.html>`__.
+        See `sub attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/sub.html>`__.
 
         Args:
             name: Object name.
@@ -1373,7 +1373,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `topic attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/topic.html>`__.
+        See `topic attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/topic.html>`__.
 
         Args:
             name: Object name.
@@ -1404,7 +1404,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `authinfo attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/authinfo.html>`__.
+        See `authinfo attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/authinfo.html>`__.
 
         Args:
             name: Object name.
@@ -1435,7 +1435,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `authrec attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/authrec.html>`__.
+        See `authrec attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/authrec.html>`__.
 
         Args:
             name: Object name.
@@ -1496,7 +1496,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cfstruct attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
+        See `cfstruct attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
 
         Args:
             name: Object name.
@@ -1527,7 +1527,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -1558,7 +1558,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `comminfo attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/comminfo.html>`__.
+        See `comminfo attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/comminfo.html>`__.
 
         Args:
             name: Object name.
@@ -1589,7 +1589,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `listener attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/listener.html>`__.
+        See `listener attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/listener.html>`__.
 
         Args:
             name: Object name.
@@ -1620,7 +1620,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `namelist attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/namelist.html>`__.
+        See `namelist attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/namelist.html>`__.
 
         Args:
             name: Object name.
@@ -1651,7 +1651,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `policy attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/policy.html>`__.
+        See `policy attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/policy.html>`__.
 
         Args:
             name: Object name.
@@ -1682,7 +1682,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `process attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/process.html>`__.
+        See `process attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/process.html>`__.
 
         Args:
             name: Object name.
@@ -1743,7 +1743,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1774,7 +1774,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1805,7 +1805,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1836,7 +1836,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1867,7 +1867,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -1898,7 +1898,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `service attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/service.html>`__.
+        See `service attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/service.html>`__.
 
         Args:
             name: Object name.
@@ -1929,7 +1929,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `stgclass attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/stgclass.html>`__.
+        See `stgclass attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/stgclass.html>`__.
 
         Args:
             name: Object name.
@@ -1960,7 +1960,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `sub attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/sub.html>`__.
+        See `sub attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/sub.html>`__.
 
         Args:
             name: Object name.
@@ -1991,7 +1991,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `topic attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/topic.html>`__.
+        See `topic attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/topic.html>`__.
 
         Args:
             name: Object name.
@@ -2023,7 +2023,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `apstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/apstatus.html>`__.
+        See `apstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/apstatus.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2060,7 +2060,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `archive attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/archive.html>`__.
+        See `archive attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/archive.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2097,7 +2097,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `authinfo attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/authinfo.html>`__.
+        See `authinfo attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/authinfo.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2134,7 +2134,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `authrec attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/authrec.html>`__.
+        See `authrec attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/authrec.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2171,7 +2171,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `authserv attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/authserv.html>`__.
+        See `authserv attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/authserv.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2208,7 +2208,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cfstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cfstatus.html>`__.
+        See `cfstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cfstatus.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2245,7 +2245,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cfstruct attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
+        See `cfstruct attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2282,7 +2282,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2319,7 +2319,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `chinit attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/chinit.html>`__.
+        See `chinit attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/chinit.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2356,7 +2356,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `chlauth attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/chlauth.html>`__.
+        See `chlauth attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/chlauth.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2393,7 +2393,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `chstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/chstatus.html>`__.
+        See `chstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/chstatus.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2430,7 +2430,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `clusqmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/clusqmgr.html>`__.
+        See `clusqmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/clusqmgr.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2498,7 +2498,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `comminfo attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/comminfo.html>`__.
+        See `comminfo attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/comminfo.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2535,7 +2535,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `conn attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/conn.html>`__.
+        See `conn attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/conn.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2572,7 +2572,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `entauth attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/entauth.html>`__.
+        See `entauth attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/entauth.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2609,7 +2609,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `group attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/group.html>`__.
+        See `group attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/group.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2646,7 +2646,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `listener attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/listener.html>`__.
+        See `listener attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/listener.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2683,7 +2683,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `log attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/log.html>`__.
+        See `log attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/log.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2720,7 +2720,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `lsstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/lsstatus.html>`__.
+        See `lsstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/lsstatus.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2793,7 +2793,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `namelist attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/namelist.html>`__.
+        See `namelist attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/namelist.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2830,7 +2830,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `policy attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/policy.html>`__.
+        See `policy attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/policy.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2867,7 +2867,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `process attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/process.html>`__.
+        See `process attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/process.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2904,7 +2904,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `pubsub attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/pubsub.html>`__.
+        See `pubsub attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/pubsub.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -2939,7 +2939,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -2971,7 +2971,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmstatus.html>`__.
+        See `qmstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmstatus.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -3005,7 +3005,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qstatus.html>`__.
+        See `qstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qstatus.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3042,7 +3042,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3079,7 +3079,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `sbstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/sbstatus.html>`__.
+        See `sbstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/sbstatus.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3116,7 +3116,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `security attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/security.html>`__.
+        See `security attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/security.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3153,7 +3153,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `service attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/service.html>`__.
+        See `service attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/service.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3190,7 +3190,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `smds attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/smds.html>`__.
+        See `smds attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/smds.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3227,7 +3227,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `smdsconn attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/smdsconn.html>`__.
+        See `smdsconn attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/smdsconn.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3264,7 +3264,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `stgclass attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/stgclass.html>`__.
+        See `stgclass attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/stgclass.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3301,7 +3301,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `sub attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/sub.html>`__.
+        See `sub attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/sub.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3338,7 +3338,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `svstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/svstatus.html>`__.
+        See `svstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/svstatus.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3483,7 +3483,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `topic attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/topic.html>`__.
+        See `topic attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/topic.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3520,7 +3520,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `tpstatus attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/tpstatus.html>`__.
+        See `tpstatus attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/tpstatus.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3593,7 +3593,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `usage attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/usage.html>`__.
+        See `usage attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/usage.html>`__.
 
         Args:
             name: Object name or generic pattern.
@@ -3629,7 +3629,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -3660,7 +3660,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -3690,7 +3690,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -3720,7 +3720,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -3781,7 +3781,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cfstruct attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
+        See `cfstruct attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
 
         Args:
             name: Object name.
@@ -3812,7 +3812,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cluster attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cluster.html>`__.
+        See `cluster attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cluster.html>`__.
 
         Args:
             name: Object name.
@@ -3842,7 +3842,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -3872,7 +3872,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `security attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/security.html>`__.
+        See `security attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/security.html>`__.
 
         Args:
             name: Object name.
@@ -3903,7 +3903,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cfstruct attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
+        See `cfstruct attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cfstruct.html>`__.
 
         Args:
             name: Object name.
@@ -3934,7 +3934,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -3965,7 +3965,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `cluster attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/cluster.html>`__.
+        See `cluster attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/cluster.html>`__.
 
         Args:
             name: Object name.
@@ -3995,7 +3995,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -4025,7 +4025,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `queue attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/queue.html>`__.
+        See `queue attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/queue.html>`__.
 
         Args:
             name: Object name.
@@ -4056,7 +4056,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `smds attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/smds.html>`__.
+        See `smds attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/smds.html>`__.
 
         Args:
             name: Object name.
@@ -4117,7 +4117,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -4148,7 +4148,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `indoubt attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/indoubt.html>`__.
+        See `indoubt attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/indoubt.html>`__.
 
         Args:
             name: Object name.
@@ -4178,7 +4178,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -4208,7 +4208,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `security attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/security.html>`__.
+        See `security attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/security.html>`__.
 
         Args:
             name: Object name.
@@ -4239,7 +4239,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `archive attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/archive.html>`__.
+        See `archive attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/archive.html>`__.
 
         Args:
             name: Object name.
@@ -4270,7 +4270,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `authrec attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/authrec.html>`__.
+        See `authrec attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/authrec.html>`__.
 
         Args:
             name: Object name.
@@ -4301,7 +4301,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `chlauth attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/chlauth.html>`__.
+        See `chlauth attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/chlauth.html>`__.
 
         Args:
             name: Object name.
@@ -4332,7 +4332,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `log attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/log.html>`__.
+        See `log attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/log.html>`__.
 
         Args:
             name: Object name.
@@ -4363,7 +4363,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `policy attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/policy.html>`__.
+        See `policy attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/policy.html>`__.
 
         Args:
             name: Object name.
@@ -4424,7 +4424,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -4455,7 +4455,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `chinit attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/chinit.html>`__.
+        See `chinit attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/chinit.html>`__.
 
         Args:
             name: Object name.
@@ -4514,7 +4514,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `listener attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/listener.html>`__.
+        See `listener attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/listener.html>`__.
 
         Args:
             name: Object name.
@@ -4544,7 +4544,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -4574,7 +4574,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `service attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/service.html>`__.
+        See `service attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/service.html>`__.
 
         Args:
             name: Object name.
@@ -4605,7 +4605,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `smdsconn attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/smdsconn.html>`__.
+        See `smdsconn attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/smdsconn.html>`__.
 
         Args:
             name: Object name.
@@ -4666,7 +4666,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `channel attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/channel.html>`__.
+        See `channel attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/channel.html>`__.
 
         Args:
             name: Object name.
@@ -4697,7 +4697,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `chinit attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/chinit.html>`__.
+        See `chinit attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/chinit.html>`__.
 
         Args:
             name: Object name.
@@ -4756,7 +4756,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `conn attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/conn.html>`__.
+        See `conn attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/conn.html>`__.
 
         Args:
             name: Object name.
@@ -4787,7 +4787,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `listener attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/listener.html>`__.
+        See `listener attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/listener.html>`__.
 
         Args:
             name: Object name.
@@ -4817,7 +4817,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped
@@ -4847,7 +4847,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `service attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/service.html>`__.
+        See `service attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/service.html>`__.
 
         Args:
             name: Object name.
@@ -4878,7 +4878,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `smdsconn attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/smdsconn.html>`__.
+        See `smdsconn attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/smdsconn.html>`__.
 
         Args:
             name: Object name.
@@ -4938,7 +4938,7 @@ class MQRESTCommandMixin:
 
         See `MQSC reference <https://www.ibm.com/docs/en/ibm-mq/9.4?topic=reference-mqsc-commands>`__
         for command details.
-        See `qmgr attribute mappings <https://wphillipmoore.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
+        See `qmgr attribute mappings <https://mq-rest-admin-project.github.io/mq-rest-admin-python/mappings/qmgr.html>`__.
 
         Args:
             request_parameters: Request attributes as a dict. Mapped


### PR DESCRIPTION
## Summary

- Update ~100 docstring URLs in `commands.py` from `wphillipmoore.github.io` to `mq-rest-admin-project.github.io`
- Update clone URL in `docs-setup.sh` to point to the new org
- Update PyPI trusted publisher references in `release-workflow.md`

Ref #497

## Test plan

- [ ] CI passes (lint, typecheck, security scans)
- [ ] Verify docstring URLs point to correct docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)